### PR TITLE
Fix build errors when using old compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,5 @@ branches:
 
 sudo: false
 
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++-5
-
 env:
-  - CXX=g++-5
+  - CXX=clang++

--- a/binding.gyp
+++ b/binding.gyp
@@ -42,6 +42,9 @@
                 "target_name": "tests",
                 "type": "executable",
                 "cflags_cc": ["-fexceptions"],
+                "defines": [
+                    "CATCH_CONFIG_CPP11_NO_IS_ENUM"
+                ],
                 "sources": [
                     "test/native/patch-test.cc",
                     "test/native/tests.cc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superstring",
-  "version": "1.0.1",
+  "version": "1.0.2-0",
   "description": "A data structure to efficiently represent the results of applying patches.",
   "main": "./build/Release/superstring",
   "scripts": {

--- a/src/core/optional.h
+++ b/src/core/optional.h
@@ -6,7 +6,7 @@ template <typename T> class optional {
   bool is_some;
 
 public:
-  optional(T value) : value{value}, is_some{true} {}
+  optional(const T &value) : value{value}, is_some{true} {}
   optional() : value{T()}, is_some{false} {}
 
 

--- a/src/core/optional.h
+++ b/src/core/optional.h
@@ -6,8 +6,8 @@ template <typename T> class optional {
   bool is_some;
 
 public:
-  optional(const T &value) : value{value}, is_some{true} {}
-  optional() : value{T()}, is_some{false} {}
+  optional(const T &value) : value(value), is_some(true) {}
+  optional() : value(T()), is_some(false) {}
 
 
   const T &operator*() const { return value; }


### PR DESCRIPTION
This way, projects that use this module (e.g. [text-buffer](https://github.com/atom/text-buffer/pull/191)) don't have to update their build dependencies.