### PR TITLE
Store marker ids in a flat_set rather than an unordered_set

### DIFF
--- a/src/bindings/marker-index-wrapper.cc
+++ b/src/bindings/marker-index-wrapper.cc
@@ -8,7 +8,6 @@
 #include <iostream>
 
 using namespace v8;
-using std::unordered_set;
 using std::unordered_map;
 
 static Nan::Persistent<String> start_string;
@@ -70,7 +69,7 @@ void MarkerIndexWrapper::GenerateRandomNumber(const Nan::FunctionCallbackInfo<Va
   info.GetReturnValue().Set(Nan::New<v8::Number>(random));
 }
 
-Local<Set> MarkerIndexWrapper::MarkerIdsToJS(const unordered_set<MarkerIndex::MarkerId> &marker_ids) {
+Local<Set> MarkerIndexWrapper::MarkerIdsToJS(const MarkerIndex::MarkerIdSet &marker_ids) {
   Isolate *isolate = v8::Isolate::GetCurrent();
   Local<Context> context = isolate->GetCurrentContext();
   Local<v8::Set> js_set = v8::Set::New(isolate);
@@ -215,7 +214,7 @@ void MarkerIndexWrapper::FindIntersecting(const Nan::FunctionCallbackInfo<Value>
   Nan::Maybe<Point> end = PointWrapper::PointFromJS(Nan::To<Object>(info[1]));
 
   if (start.IsJust() && end.IsJust()) {
-    unordered_set<MarkerIndex::MarkerId> result = wrapper->marker_index.FindIntersecting(start.FromJust(), end.FromJust());
+    MarkerIndex::MarkerIdSet result = wrapper->marker_index.FindIntersecting(start.FromJust(), end.FromJust());
     info.GetReturnValue().Set(MarkerIdsToJS(result));
   }
 }
@@ -227,7 +226,7 @@ void MarkerIndexWrapper::FindContaining(const Nan::FunctionCallbackInfo<Value> &
   Nan::Maybe<Point> end = PointWrapper::PointFromJS(Nan::To<Object>(info[1]));
 
   if (start.IsJust() && end.IsJust()) {
-    unordered_set<MarkerIndex::MarkerId> result = wrapper->marker_index.FindContaining(start.FromJust(), end.FromJust());
+    MarkerIndex::MarkerIdSet result = wrapper->marker_index.FindContaining(start.FromJust(), end.FromJust());
     info.GetReturnValue().Set(MarkerIdsToJS(result));
   }
 }
@@ -239,7 +238,7 @@ void MarkerIndexWrapper::FindContainedIn(const Nan::FunctionCallbackInfo<Value> 
   Nan::Maybe<Point> end = PointWrapper::PointFromJS(Nan::To<Object>(info[1]));
 
   if (start.IsJust() && end.IsJust()) {
-    unordered_set<MarkerIndex::MarkerId> result = wrapper->marker_index.FindContainedIn(start.FromJust(), end.FromJust());
+    MarkerIndex::MarkerIdSet result = wrapper->marker_index.FindContainedIn(start.FromJust(), end.FromJust());
     info.GetReturnValue().Set(MarkerIdsToJS(result));
   }
 }
@@ -251,7 +250,7 @@ void MarkerIndexWrapper::FindStartingIn(const Nan::FunctionCallbackInfo<Value> &
   Nan::Maybe<Point> end = PointWrapper::PointFromJS(Nan::To<Object>(info[1]));
 
   if (start.IsJust() && end.IsJust()) {
-    unordered_set<MarkerIndex::MarkerId> result = wrapper->marker_index.FindStartingIn(start.FromJust(), end.FromJust());
+    MarkerIndex::MarkerIdSet result = wrapper->marker_index.FindStartingIn(start.FromJust(), end.FromJust());
     info.GetReturnValue().Set(MarkerIdsToJS(result));
   }
 }
@@ -262,7 +261,7 @@ void MarkerIndexWrapper::FindStartingAt(const Nan::FunctionCallbackInfo<Value> &
   Nan::Maybe<Point> position = PointWrapper::PointFromJS(Nan::To<Object>(info[0]));
 
   if (position.IsJust()) {
-    unordered_set<MarkerIndex::MarkerId> result = wrapper->marker_index.FindStartingAt(position.FromJust());
+    MarkerIndex::MarkerIdSet result = wrapper->marker_index.FindStartingAt(position.FromJust());
     info.GetReturnValue().Set(MarkerIdsToJS(result));
   }
 }
@@ -274,7 +273,7 @@ void MarkerIndexWrapper::FindEndingIn(const Nan::FunctionCallbackInfo<Value> &in
   Nan::Maybe<Point> end = PointWrapper::PointFromJS(Nan::To<Object>(info[1]));
 
   if (start.IsJust() && end.IsJust()) {
-    unordered_set<MarkerIndex::MarkerId> result = wrapper->marker_index.FindEndingIn(start.FromJust(), end.FromJust());
+    MarkerIndex::MarkerIdSet result = wrapper->marker_index.FindEndingIn(start.FromJust(), end.FromJust());
     info.GetReturnValue().Set(MarkerIdsToJS(result));
   }
 }
@@ -285,7 +284,7 @@ void MarkerIndexWrapper::FindEndingAt(const Nan::FunctionCallbackInfo<Value> &in
   Nan::Maybe<Point> position = PointWrapper::PointFromJS(Nan::To<Object>(info[0]));
 
   if (position.IsJust()) {
-    unordered_set<MarkerIndex::MarkerId> result = wrapper->marker_index.FindEndingAt(position.FromJust());
+    MarkerIndex::MarkerIdSet result = wrapper->marker_index.FindEndingAt(position.FromJust());
     info.GetReturnValue().Set(MarkerIdsToJS(result));
   }
 }

--- a/src/bindings/marker-index-wrapper.h
+++ b/src/bindings/marker-index-wrapper.h
@@ -10,7 +10,7 @@ private:
   static void New(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void GenerateRandomNumber(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static bool IsFinite(v8::Local<v8::Integer> number);
-  static v8::Local<v8::Set> MarkerIdsToJS(const std::unordered_set<MarkerIndex::MarkerId> &marker_ids);
+  static v8::Local<v8::Set> MarkerIdsToJS(const MarkerIndex::MarkerIdSet &marker_ids);
   static v8::Local<v8::Object> SnapshotToJS(const std::unordered_map<MarkerIndex::MarkerId, Range> &snapshot);
   static Nan::Maybe<MarkerIndex::MarkerId> MarkerIdFromJS(Nan::MaybeLocal<v8::Integer> maybe_id);
   static Nan::Maybe<bool> BoolFromJS(Nan::MaybeLocal<v8::Boolean> maybe_boolean);

--- a/src/core/flat_set.h
+++ b/src/core/flat_set.h
@@ -1,0 +1,65 @@
+#ifndef SUPERSTRING_FLAT_SET_H
+#define SUPERSTRING_FLAT_SET_H
+
+#include <vector>
+#include <algorithm>
+
+template <typename T> class flat_set {
+  typedef std::vector<T> contents_type;
+  contents_type contents;
+
+public:
+  typedef typename contents_type::iterator iterator;
+  typedef typename contents_type::const_iterator const_iterator;
+
+  void insert(T value) {
+    auto iter = std::lower_bound(contents.begin(), contents.end(), value);
+    if (iter == contents.end() || *iter != value) {
+      contents.insert(iter, value);
+    }
+  }
+
+  void insert(const_iterator start, const_iterator end) {
+    for (auto i = start; i != end; i++) {
+      insert(*i);
+    }
+  }
+
+  iterator erase(const iterator &iter) {
+    return contents.erase(iter);
+  }
+
+  void erase(T value) {
+    auto end = this->end();
+    auto iter = std::lower_bound(begin(), end, value);
+    if (iter != end && *iter == value) {
+      erase(iter);
+    }
+  }
+
+  iterator begin() {
+    return contents.begin();
+  }
+
+  const_iterator begin() const {
+    return contents.begin();
+  }
+
+  iterator end() {
+    return contents.end();
+  }
+
+  const_iterator end() const {
+    return contents.end();
+  }
+
+  size_t count(T value) const {
+    return std::binary_search(contents.begin(), contents.end(), value) ? 1 : 0;
+  }
+
+  size_t size() const {
+    return contents.size();
+  }
+};
+
+#endif // SUPERSTRING_FLAT_SET_H

--- a/src/core/marker-index.h
+++ b/src/core/marker-index.h
@@ -4,18 +4,20 @@
 #include <map>
 #include <random>
 #include <unordered_map>
-#include <unordered_set>
+#include "flat_set.h"
 #include "point.h"
 #include "range.h"
 
 class MarkerIndex {
 public:
   using MarkerId = unsigned;
+  using MarkerIdSet = flat_set<MarkerId>;
+
   struct SpliceResult {
-    std::unordered_set<MarkerId> touch;
-    std::unordered_set<MarkerId> inside;
-    std::unordered_set<MarkerId> overlap;
-    std::unordered_set<MarkerId> surround;
+    flat_set<MarkerId> touch;
+    flat_set<MarkerId> inside;
+    flat_set<MarkerId> overlap;
+    flat_set<MarkerId> surround;
   };
 
   MarkerIndex(unsigned seed);
@@ -29,13 +31,13 @@ public:
   Range GetRange(MarkerId id) const;
 
   int Compare(MarkerId id1, MarkerId id2) const;
-  std::unordered_set<MarkerId> FindIntersecting(Point start, Point end);
-  std::unordered_set<MarkerId> FindContaining(Point start, Point end);
-  std::unordered_set<MarkerId> FindContainedIn(Point start, Point end);
-  std::unordered_set<MarkerId> FindStartingIn(Point start, Point end);
-  std::unordered_set<MarkerId> FindStartingAt(Point position);
-  std::unordered_set<MarkerId> FindEndingIn(Point start, Point end);
-  std::unordered_set<MarkerId> FindEndingAt(Point position);
+  flat_set<MarkerId> FindIntersecting(Point start, Point end);
+  flat_set<MarkerId> FindContaining(Point start, Point end);
+  flat_set<MarkerId> FindContainedIn(Point start, Point end);
+  flat_set<MarkerId> FindStartingIn(Point start, Point end);
+  flat_set<MarkerId> FindStartingAt(Point position);
+  flat_set<MarkerId> FindEndingIn(Point start, Point end);
+  flat_set<MarkerId> FindEndingAt(Point position);
 
   std::unordered_map<MarkerId, Range> Dump();
 
@@ -47,10 +49,10 @@ private:
     Node *left;
     Node *right;
     Point left_extent;
-    std::unordered_set<MarkerId> left_marker_ids;
-    std::unordered_set<MarkerId> right_marker_ids;
-    std::unordered_set<MarkerId> start_marker_ids;
-    std::unordered_set<MarkerId> end_marker_ids;
+    flat_set<MarkerId> left_marker_ids;
+    flat_set<MarkerId> right_marker_ids;
+    flat_set<MarkerId> start_marker_ids;
+    flat_set<MarkerId> end_marker_ids;
     int priority;
 
     Node(Node *parent, Point left_extent);
@@ -64,10 +66,10 @@ private:
     Node* InsertMarkerStart(const MarkerId &id, const Point &start_position, const Point &end_position);
     Node* InsertMarkerEnd(const MarkerId &id, const Point &start_position, const Point &end_position);
     Node* InsertSpliceBoundary(const Point &position, bool is_insertion_end);
-    void FindIntersecting(const Point &start, const Point &end, std::unordered_set<MarkerId> *result);
-    void FindContainedIn(const Point &start, const Point &end, std::unordered_set<MarkerId> *result);
-    void FindStartingIn(const Point &start, const Point &end, std::unordered_set<MarkerId> *result);
-    void FindEndingIn(const Point &start, const Point &end, std::unordered_set<MarkerId> *result);
+    void FindIntersecting(const Point &start, const Point &end, flat_set<MarkerId> *result);
+    void FindContainedIn(const Point &start, const Point &end, flat_set<MarkerId> *result);
+    void FindStartingIn(const Point &start, const Point &end, flat_set<MarkerId> *result);
+    void FindEndingIn(const Point &start, const Point &end, flat_set<MarkerId> *result);
     std::unordered_map<MarkerId, Range> Dump();
 
   private:
@@ -80,7 +82,7 @@ private:
     void MarkLeft(const MarkerId &id, const Point &start_position, const Point &end_position);
     Node* InsertLeftChild(const Point &position);
     Node* InsertRightChild(const Point &position);
-    void CheckIntersection(const Point &start, const Point &end, std::unordered_set<MarkerId> *results);
+    void CheckIntersection(const Point &start, const Point &end, flat_set<MarkerId> *results);
     void CacheNodePosition() const;
 
     MarkerIndex *marker_index;
@@ -99,8 +101,8 @@ private:
   void BubbleNodeDown(Node *node);
   void RotateNodeLeft(Node *pivot);
   void RotateNodeRight(Node *pivot);
-  void GetStartingAndEndingMarkersWithinSubtree(const Node *node, std::unordered_set<MarkerId> *starting, std::unordered_set<MarkerId> *ending);
-  void PopulateSpliceInvalidationSets(SpliceResult *invalidated, const Node *start_node, const Node *end_node, const std::unordered_set<MarkerId> &starting_inside_splice, const std::unordered_set<MarkerId> &ending_inside_splice);
+  void GetStartingAndEndingMarkersWithinSubtree(const Node *node, flat_set<MarkerId> *starting, flat_set<MarkerId> *ending);
+  void PopulateSpliceInvalidationSets(SpliceResult *invalidated, const Node *start_node, const Node *end_node, const flat_set<MarkerId> &starting_inside_splice, const flat_set<MarkerId> &ending_inside_splice);
 
   std::default_random_engine random_engine;
   std::uniform_int_distribution<int> random_distribution;
@@ -108,7 +110,7 @@ private:
   std::map<MarkerId, Node*> start_nodes_by_id;
   std::map<MarkerId, Node*> end_nodes_by_id;
   Iterator iterator;
-  std::unordered_set<MarkerId> exclusive_marker_ids;
+  flat_set<MarkerId> exclusive_marker_ids;
   mutable std::unordered_map<const Node*, Point> node_position_cache;
 };
 


### PR DESCRIPTION
Before:

```
sequential inserts: 79.037ms
inserts: 141.911ms
range queries: 783.089ms
splices: 6839.141ms
deletes: 49.744ms
```

After:

```
sequential inserts: 72.125ms
inserts: 83.611ms
range queries: 593.052ms
splices: 3616.571ms
deletes: 72.975ms
```

Everything is faster except for deletions, which are still quite fast. I was surprised to see that sequential insertions were not improved as significantly as random insertions.

/cc @nathansobo