### PR TITLE
Fix Patch::delete_root

### DIFF
--- a/script/test-with-debug-graph.sh
+++ b/script/test-with-debug-graph.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo '<?xml version="1.0"?>' > debug.html
+echo '<style> svg { width: 100%; margin-bottom: 10px; } </style>' >> debug.html
+node_modules/.bin/mocha test/js/*.js 2> >(dot -Tsvg >> debug.html)

--- a/src/core/patch.cc
+++ b/src/core/patch.cc
@@ -1031,14 +1031,20 @@ void Patch::delete_root() {
   Node *node = root, *parent = nullptr;
   while (true) {
     if (node->left) {
+      Node *left = node->left;
       rotate_node_right(node->left, node, parent);
+      parent = left;
     } else if (node->right) {
+      Node *right = node->right;
       rotate_node_left(node->right, node, parent);
+      parent = right;
     } else if (parent) {
       if (parent->left == node) {
         delete_node(&parent->left);
+        break;
       } else if (parent->right == node) {
         delete_node(&parent->right);
+        break;
       }
     } else {
       delete_node(&root);

--- a/src/core/patch.cc
+++ b/src/core/patch.cc
@@ -1395,7 +1395,27 @@ Patch::Patch(const vector<uint8_t> &input)
 }
 
 ostream &operator<<(ostream &stream, const Patch::Hunk &hunk) {
-  return stream <<
-    "{Hunk old-range: (" << hunk.old_start << " - " << hunk.old_end << ")" <<
-    ", new-range: (" << hunk.new_start << " - " << hunk.new_end << ")}";
+  stream
+    << "{Hunk "
+    << "old_range: (" << hunk.old_start << " - " << hunk.old_end << ")"
+    << ", new_range: (" << hunk.new_start << " - " << hunk.new_end << ")"
+    << ", old_text: ";
+
+  if (hunk.old_text) {
+    stream << hunk.old_text;
+  } else {
+    stream << "null";
+  }
+
+  stream << ", new_text: ";
+
+  if (hunk.new_text) {
+    stream << hunk.new_text;
+  } else {
+    stream << "null";
+  }
+
+  stream << "}";
+
+  return stream;
 }

--- a/test/js/patch.test.js
+++ b/test/js/patch.test.js
@@ -156,6 +156,20 @@ describe('Patch', function () {
     }])
   })
 
+  it('removes a hunk when it becomes empty', () => {
+    const patch = new Patch()
+    patch.splice({row: 1, column: 0}, {row: 0, column: 0}, {row: 0, column: 5})
+    patch.splice({row: 2, column: 0}, {row: 0, column: 0}, {row: 0, column: 5})
+    patch.splice({row: 1, column: 0}, {row: 0, column: 5}, {row: 0, column: 0})
+
+    assert.deepEqual(JSON.parse(JSON.stringify(patch.getHunks())), [{
+      oldStart: {row: 2, column: 0},
+      newStart: {row: 2, column: 0},
+      oldEnd: {row: 2, column: 0},
+      newEnd: {row: 2, column: 5}
+    }])
+  })
+
   it('correctly records random splices', function () {
     this.timeout(Infinity)
 


### PR DESCRIPTION
Refs https://github.com/atom/atom/issues/4619

Previously, we were always deleting the entire tree when calling `Patch::delete_root` because we were never assigning the parent after performing a rotation. Pretty scary that our randomized testing never caught this.

I also included some other changes that were helpful for debugging.

/cc @maxbrunsfeld 