### PR TITLE
Fix edge cases in Patch::splice_old

### DIFF
--- a/test/js/helpers/test-document.js
+++ b/test/js/helpers/test-document.js
@@ -41,12 +41,12 @@ class TestDocument {
     }
   }
 
-  performRandomSplice () {
+  performRandomSplice (upperCase) {
     let deletedRange = this.buildRandomRange()
     let start = deletedRange.start
     let deletedText = this.getTextInRange(start, deletedRange.end)
     let deletedExtent = pointHelpers.traversalDistance(deletedRange.end, deletedRange.start)
-    let insertedText = this.buildRandomLines(0, 3, true).join('\n')
+    let insertedText = this.buildRandomLines(0, 3, upperCase).join('\n')
     let insertedExtent = textHelpers.getExtent(insertedText)
     this.splice(start, deletedExtent, insertedText)
     return {start, deletedExtent, insertedExtent, deletedText, insertedText}


### PR DESCRIPTION
@maxbrunsfeld this doesn't look terrible... looks like we just have different assumptions when updating the reference document when testing splice old in the presence of multiple adjacent unmerged insertions. Didn't have time to figure it out fully though.