### PR TITLE
Add MarkerIndex::findBoundariesIn(start, end)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build
 .clang_complete
 
 /browser.js
-emsdk_portable
+emsdk-portable

--- a/README.md
+++ b/README.md
@@ -162,3 +162,18 @@ Returns a set with the ids of all markers starting at the specified point.
 ##### `findEndingAt (position)`
 
 Returns a set with the ids of all markers ending at the specified point.
+
+##### `findBoundariesIn (start, end)`
+
+A boundary is a position in the index where a marker starts or ends. Multiple markers starting and/or ending at the same position describe only one boundary. This method returns an object containing all the boundaries in the specified point range, and an array of marker ids that overlap the specified start position. For example:
+
+```js
+{
+  containingStart: [1, 2, 3, 4],
+  boundaries: [
+    {position: {row: 0, column: 1}, starting: new Set([5, 6]), ending: new Set()},
+    {position: {row: 1, column: 0}, starting: new Set(), ending: new Set([5])}
+    {position: {row: 2, column: 0}, starting: new Set(), ending: new Set([6])}
+  ]
+}
+```

--- a/script/build-browser-version.sh
+++ b/script/build-browser-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-EM_COMPILER_PATH=$(find emsdk_portable -name em++ | head -n1)
+EM_COMPILER_PATH=$(find emsdk-portable -name em++ | head -n1)
 
 echo "Running ${EM_COMPILER_PATH}"
 ${EM_COMPILER_PATH}                     \

--- a/script/install-emscripten.sh
+++ b/script/install-emscripten.sh
@@ -3,7 +3,7 @@
 set -e
 
 EMSCRIPTEN_DOWNLOAD_URL='https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz'
-EMSDK_PATH="./emsdk_portable/emsdk"
+EMSDK_PATH="./emsdk-portable/emsdk"
 
 if [ ! -f $EMSDK_PATH ]; then
   echo 'Downloading emscripten SDK installer...'

--- a/src/bindings/em/auto-wrap.h
+++ b/src/bindings/em/auto-wrap.h
@@ -134,6 +134,35 @@ struct em_wrap_type<MarkerIndex::SpliceResult> : public em_wrap_type_base<Marker
 };
 
 template <>
+struct em_wrap_type<MarkerIndex::Boundary> : public em_wrap_type_base<MarkerIndex::Boundary, emscripten::val> {
+  static MarkerIndex::Boundary receive(emscripten::val const &value) {
+    throw std::runtime_error("Unimplemented");
+  }
+
+  static emscripten::val transmit(MarkerIndex::Boundary const &boundary) {
+    auto result = emscripten::val::object();
+    result.set("position", em_transmit(boundary.position));
+    result.set("starting", em_transmit(boundary.starting));
+    result.set("ending", em_transmit(boundary.ending));
+    return result;
+  }
+};
+
+template <>
+struct em_wrap_type<MarkerIndex::BoundaryQueryResult> : public em_wrap_type_base<MarkerIndex::BoundaryQueryResult, emscripten::val> {
+  static MarkerIndex::BoundaryQueryResult receive(emscripten::val const &value) {
+    throw std::runtime_error("Unimplemented");
+  }
+
+  static emscripten::val transmit(MarkerIndex::BoundaryQueryResult const &query_result) {
+    auto result = emscripten::val::object();
+    result.set("containingStart", em_transmit(query_result.containing_start));
+    result.set("boundaries", em_transmit(query_result.boundaries));
+    return result;
+  }
+};
+
+template <>
 struct em_wrap_type<Text> : public em_wrap_type_base<Text, std::string> {
   static Text receive(std::string const &str) {
     return Text(str.begin(), str.end());

--- a/src/bindings/em/marker-index.cc
+++ b/src/bindings/em/marker-index.cc
@@ -23,6 +23,7 @@ EMSCRIPTEN_BINDINGS(MarkerIndex) {
     .function("findStartingAt", WRAP(&MarkerIndex::find_starting_at))
     .function("findEndingIn", WRAP(&MarkerIndex::find_ending_in))
     .function("findEndingAt", WRAP(&MarkerIndex::find_ending_at))
+    .function("findBoundariesIn", WRAP(&MarkerIndex::find_boundaries_in))
     .function("dump", WRAP(&MarkerIndex::dump));
 
   emscripten::value_object<MarkerIndex::SpliceResult>("SpliceResult")
@@ -30,4 +31,13 @@ EMSCRIPTEN_BINDINGS(MarkerIndex) {
     .field("inside", &MarkerIndex::SpliceResult::inside)
     .field("overlap", &MarkerIndex::SpliceResult::overlap)
     .field("surround", &MarkerIndex::SpliceResult::surround);
+
+  emscripten::value_object<MarkerIndex::BoundaryQueryResult>("BoundaryQueryResult")
+    .field("containing_start", &MarkerIndex::BoundaryQueryResult::containing_start)
+    .field("boundaries", &MarkerIndex::BoundaryQueryResult::boundaries);
+
+  emscripten::value_object<MarkerIndex::Boundary>("Boundary")
+    .field("position", &MarkerIndex::Boundary::position)
+    .field("starting", &MarkerIndex::Boundary::starting)
+    .field("ending", &MarkerIndex::Boundary::ending);
 }

--- a/src/bindings/marker-index-wrapper.cc
+++ b/src/bindings/marker-index-wrapper.cc
@@ -82,7 +82,7 @@ void MarkerIndexWrapper::generate_random_number(const Nan::FunctionCallbackInfo<
   info.GetReturnValue().Set(Nan::New<v8::Number>(random));
 }
 
-Local<Set> MarkerIndexWrapper::marker_ids_to_js(const MarkerIndex::MarkerIdSet &marker_ids) {
+Local<Set> MarkerIndexWrapper::marker_ids_set_to_js(const MarkerIndex::MarkerIdSet &marker_ids) {
   Isolate *isolate = v8::Isolate::GetCurrent();
   Local<Context> context = isolate->GetCurrentContext();
   Local<v8::Set> js_set = v8::Set::New(isolate);
@@ -96,7 +96,7 @@ Local<Set> MarkerIndexWrapper::marker_ids_to_js(const MarkerIndex::MarkerIdSet &
   return js_set;
 }
 
-Local<Array> MarkerIndexWrapper::marker_id_vector_to_js(const std::vector<MarkerIndex::MarkerId> &marker_ids) {
+Local<Array> MarkerIndexWrapper::marker_ids_vector_to_js(const std::vector<MarkerIndex::MarkerId> &marker_ids) {
   Local<Array> js_array = Nan::New<Array>(marker_ids.size());
   for (size_t i = 0; i < marker_ids.size(); i++) {
     js_array->Set(i, Nan::New<Integer>(marker_ids[i]));
@@ -196,11 +196,11 @@ void MarkerIndexWrapper::splice(const Nan::FunctionCallbackInfo<Value> &info) {
     MarkerIndex::SpliceResult result = wrapper->marker_index.splice(*start, *old_extent, *new_extent);
 
     Local<Object> invalidated = Nan::New<Object>();
-    invalidated->Set(Nan::New(touch_string), marker_ids_to_js(result.touch));
-    invalidated->Set(Nan::New(inside_string), marker_ids_to_js(result.inside));
-    invalidated->Set(Nan::New(inside_string), marker_ids_to_js(result.inside));
-    invalidated->Set(Nan::New(overlap_string), marker_ids_to_js(result.overlap));
-    invalidated->Set(Nan::New(surround_string), marker_ids_to_js(result.surround));
+    invalidated->Set(Nan::New(touch_string), marker_ids_set_to_js(result.touch));
+    invalidated->Set(Nan::New(inside_string), marker_ids_set_to_js(result.inside));
+    invalidated->Set(Nan::New(inside_string), marker_ids_set_to_js(result.inside));
+    invalidated->Set(Nan::New(overlap_string), marker_ids_set_to_js(result.overlap));
+    invalidated->Set(Nan::New(surround_string), marker_ids_set_to_js(result.surround));
     info.GetReturnValue().Set(invalidated);
   }
 }
@@ -255,7 +255,7 @@ void MarkerIndexWrapper::find_intersecting(const Nan::FunctionCallbackInfo<Value
 
   if (start && end) {
     MarkerIndex::MarkerIdSet result = wrapper->marker_index.find_intersecting(*start, *end);
-    info.GetReturnValue().Set(marker_ids_to_js(result));
+    info.GetReturnValue().Set(marker_ids_set_to_js(result));
   }
 }
 
@@ -267,7 +267,7 @@ void MarkerIndexWrapper::find_containing(const Nan::FunctionCallbackInfo<Value> 
 
   if (start && end) {
     MarkerIndex::MarkerIdSet result = wrapper->marker_index.find_containing(*start, *end);
-    info.GetReturnValue().Set(marker_ids_to_js(result));
+    info.GetReturnValue().Set(marker_ids_set_to_js(result));
   }
 }
 
@@ -279,7 +279,7 @@ void MarkerIndexWrapper::find_contained_in(const Nan::FunctionCallbackInfo<Value
 
   if (start && end) {
     MarkerIndex::MarkerIdSet result = wrapper->marker_index.find_contained_in(*start, *end);
-    info.GetReturnValue().Set(marker_ids_to_js(result));
+    info.GetReturnValue().Set(marker_ids_set_to_js(result));
   }
 }
 
@@ -291,7 +291,7 @@ void MarkerIndexWrapper::find_starting_in(const Nan::FunctionCallbackInfo<Value>
 
   if (start && end) {
     MarkerIndex::MarkerIdSet result = wrapper->marker_index.find_starting_in(*start, *end);
-    info.GetReturnValue().Set(marker_ids_to_js(result));
+    info.GetReturnValue().Set(marker_ids_set_to_js(result));
   }
 }
 
@@ -302,7 +302,7 @@ void MarkerIndexWrapper::find_starting_at(const Nan::FunctionCallbackInfo<Value>
 
   if (position) {
     MarkerIndex::MarkerIdSet result = wrapper->marker_index.find_starting_at(*position);
-    info.GetReturnValue().Set(marker_ids_to_js(result));
+    info.GetReturnValue().Set(marker_ids_set_to_js(result));
   }
 }
 
@@ -314,7 +314,7 @@ void MarkerIndexWrapper::find_ending_in(const Nan::FunctionCallbackInfo<Value> &
 
   if (start && end) {
     MarkerIndex::MarkerIdSet result = wrapper->marker_index.find_ending_in(*start, *end);
-    info.GetReturnValue().Set(marker_ids_to_js(result));
+    info.GetReturnValue().Set(marker_ids_set_to_js(result));
   }
 }
 
@@ -325,7 +325,7 @@ void MarkerIndexWrapper::find_ending_at(const Nan::FunctionCallbackInfo<Value> &
 
   if (position) {
     MarkerIndex::MarkerIdSet result = wrapper->marker_index.find_ending_at(*position);
-    info.GetReturnValue().Set(marker_ids_to_js(result));
+    info.GetReturnValue().Set(marker_ids_set_to_js(result));
   }
 }
 
@@ -338,15 +338,15 @@ void MarkerIndexWrapper::find_boundaries_in(const Nan::FunctionCallbackInfo<Valu
   if (start && end) {
     MarkerIndex::BoundaryQueryResult result = wrapper->marker_index.find_boundaries_in(*start, *end);
     Local<Object> js_result = Nan::New<Object>();
-    js_result->Set(Nan::New(containing_start_string), marker_id_vector_to_js(result.containing_start));
+    js_result->Set(Nan::New(containing_start_string), marker_ids_vector_to_js(result.containing_start));
 
     Local<Array> js_boundaries = Nan::New<Array>(result.boundaries.size());
     for (size_t i = 0; i < result.boundaries.size(); i++) {
       MarkerIndex::Boundary boundary = result.boundaries[i];
       Local<Object> js_boundary = Nan::New<Object>();
       js_boundary->Set(Nan::New(position_string), PointWrapper::from_point(boundary.position));
-      js_boundary->Set(Nan::New(starting_string), marker_ids_to_js(boundary.starting));
-      js_boundary->Set(Nan::New(ending_string), marker_ids_to_js(boundary.ending));
+      js_boundary->Set(Nan::New(starting_string), marker_ids_set_to_js(boundary.starting));
+      js_boundary->Set(Nan::New(ending_string), marker_ids_set_to_js(boundary.ending));
       js_boundaries->Set(i, js_boundary);
     }
     js_result->Set(Nan::New(boundaries_string), js_boundaries);

--- a/src/bindings/marker-index-wrapper.h
+++ b/src/bindings/marker-index-wrapper.h
@@ -11,8 +11,8 @@ private:
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void generate_random_number(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static bool is_finite(v8::Local<v8::Integer> number);
-  static v8::Local<v8::Set> marker_ids_to_js(const MarkerIndex::MarkerIdSet &marker_ids);
-  static v8::Local<v8::Array> marker_id_vector_to_js(const std::vector<MarkerIndex::MarkerId> &marker_ids);
+  static v8::Local<v8::Set> marker_ids_set_to_js(const MarkerIndex::MarkerIdSet &marker_ids);
+  static v8::Local<v8::Array> marker_ids_vector_to_js(const std::vector<MarkerIndex::MarkerId> &marker_ids);
   static v8::Local<v8::Object> snapshot_to_js(const std::unordered_map<MarkerIndex::MarkerId, Range> &snapshot);
   static optional<MarkerIndex::MarkerId> marker_id_from_js(v8::Local<v8::Value> value);
   static optional<unsigned> unsigned_from_js(v8::Local<v8::Value> value);

--- a/src/bindings/marker-index-wrapper.h
+++ b/src/bindings/marker-index-wrapper.h
@@ -12,6 +12,7 @@ private:
   static void generate_random_number(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static bool is_finite(v8::Local<v8::Integer> number);
   static v8::Local<v8::Set> marker_ids_to_js(const MarkerIndex::MarkerIdSet &marker_ids);
+  static v8::Local<v8::Array> marker_id_vector_to_js(const std::vector<MarkerIndex::MarkerId> &marker_ids);
   static v8::Local<v8::Object> snapshot_to_js(const std::unordered_map<MarkerIndex::MarkerId, Range> &snapshot);
   static optional<MarkerIndex::MarkerId> marker_id_from_js(v8::Local<v8::Value> value);
   static optional<unsigned> unsigned_from_js(v8::Local<v8::Value> value);
@@ -32,6 +33,7 @@ private:
   static void find_starting_at(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_ending_in(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_ending_at(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void find_boundaries_in(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void dump(const Nan::FunctionCallbackInfo<v8::Value> &info);
   MarkerIndexWrapper(v8::Local<v8::Number> seed);
   MarkerIndex marker_index;

--- a/src/core/marker-index.cc
+++ b/src/core/marker-index.cc
@@ -210,6 +210,55 @@ void MarkerIndex::Iterator::find_ending_in(const Point &start, const Point &end,
   }
 }
 
+void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerIndex::BoundaryQueryResult *result) {
+  reset();
+
+  if (!current_node) return;
+
+  while (true) {
+    cache_node_position();
+
+    if (start <= current_node_position) {
+      if (left_ancestor_position < start) {
+        result->containing_start.insert(
+          result->containing_start.end(),
+          current_node->left_marker_ids.begin(),
+          current_node->left_marker_ids.end()
+        );
+      }
+
+      if (current_node->left) {
+        descend_left();
+      } else {
+        break;
+      }
+    } else {
+      if (right_ancestor_position >= start) {
+        result->containing_start.insert(
+          result->containing_start.end(),
+          current_node->right_marker_ids.begin(),
+          current_node->right_marker_ids.end()
+        );
+      }
+
+      if (current_node->right) {
+        descend_right();
+      } else {
+        break;
+      }
+    }
+  }
+
+  std::sort(
+    result->containing_start.begin(),
+    result->containing_start.end(),
+    [this](MarkerId a, MarkerId b) -> bool {
+      int comparison = marker_index->compare(a, b);
+      return comparison == 0 ? a < b : comparison == -1;
+    }
+  );
+}
+
 unordered_map<MarkerIndex::MarkerId, Range> MarkerIndex::Iterator::dump() {
   reset();
 
@@ -640,6 +689,12 @@ flat_set<MarkerIndex::MarkerId> MarkerIndex::find_ending_in(Point start, Point e
 
 flat_set<MarkerIndex::MarkerId> MarkerIndex::find_ending_at(Point position) {
   return find_ending_in(position, position);
+}
+
+MarkerIndex::BoundaryQueryResult MarkerIndex::find_boundaries_in(Point start, Point end) {
+  BoundaryQueryResult result;
+  iterator.find_boundaries_in(start, end, &result);
+  return result;
 }
 
 unordered_map<MarkerIndex::MarkerId, Range> MarkerIndex::dump() {

--- a/src/core/marker-index.cc
+++ b/src/core/marker-index.cc
@@ -250,7 +250,7 @@ void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerInd
   std::sort(
     result->containing_start.begin(),
     result->containing_start.end(),
-    [this](MarkerId a, MarkerId b) -> bool {
+    [this](MarkerId a, MarkerId b) {
       int comparison = marker_index->compare(a, b);
       return comparison == 0 ? a < b : comparison == -1;
     }

--- a/src/core/marker-index.cc
+++ b/src/core/marker-index.cc
@@ -256,8 +256,7 @@ void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerInd
     }
   );
 
-  reset();
-  seek_to_first_node_greater_than_or_equal_to(start);
+  if (current_node_position < start) move_to_successor();
   while (current_node && current_node_position < end) {
     cache_node_position();
     result->boundaries.push_back({

--- a/src/core/marker-index.cc
+++ b/src/core/marker-index.cc
@@ -212,7 +212,6 @@ void MarkerIndex::Iterator::find_ending_in(const Point &start, const Point &end,
 
 void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerIndex::BoundaryQueryResult *result) {
   reset();
-
   if (!current_node) return;
 
   while (true) {
@@ -248,7 +247,6 @@ void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerInd
       }
     }
   }
-
   std::sort(
     result->containing_start.begin(),
     result->containing_start.end(),
@@ -257,6 +255,18 @@ void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerInd
       return comparison == 0 ? a < b : comparison == -1;
     }
   );
+
+  reset();
+  seek_to_first_node_greater_than_or_equal_to(start);
+  while (current_node && current_node_position < end) {
+    cache_node_position();
+    result->boundaries.push_back({
+      current_node_position,
+      current_node->start_marker_ids,
+      current_node->end_marker_ids
+    });
+    move_to_successor();
+  }
 }
 
 unordered_map<MarkerIndex::MarkerId, Range> MarkerIndex::Iterator::dump() {

--- a/src/core/marker-index.h
+++ b/src/core/marker-index.h
@@ -19,6 +19,17 @@ public:
     flat_set<MarkerId> surround;
   };
 
+  struct Boundary {
+    Point position;
+    flat_set<MarkerId> starting;
+    flat_set<MarkerId> ending;
+  };
+
+  struct BoundaryQueryResult {
+    std::vector<MarkerId> containing_start;
+    std::vector<Boundary> boundaries;
+  };
+
   MarkerIndex(unsigned seed = 0u);
   ~MarkerIndex();
   int generate_random_number();
@@ -39,6 +50,7 @@ public:
   flat_set<MarkerId> find_starting_at(Point position);
   flat_set<MarkerId> find_ending_in(Point start, Point end);
   flat_set<MarkerId> find_ending_at(Point position);
+  BoundaryQueryResult find_boundaries_in(Point start, Point end);
 
   std::unordered_map<MarkerId, Range> dump();
 
@@ -71,6 +83,7 @@ private:
     void find_contained_in(const Point &start, const Point &end, flat_set<MarkerId> *result);
     void find_starting_in(const Point &start, const Point &end, flat_set<MarkerId> *result);
     void find_ending_in(const Point &start, const Point &end, flat_set<MarkerId> *result);
+    void find_boundaries_in(const Point start, const Point end, BoundaryQueryResult *result);
     std::unordered_map<MarkerId, Range> dump();
 
   private:

--- a/test/js/marker-index.test.js
+++ b/test/js/marker-index.test.js
@@ -4,7 +4,7 @@ const {assert} = require('chai')
 const {MarkerIndex} = require('../..')
 
 describe('MarkerIndex', () => {
-  it.only('maintains correct marker positions during randomized insertions and mutations', function () {
+  it('maintains correct marker positions during randomized insertions and mutations', function () {
     this.timeout(Infinity)
 
     let seed, seedMessage, random, markerIndex, markers, idCounter
@@ -324,6 +324,7 @@ describe('MarkerIndex', () => {
 
         const {containingStart, boundaries} = markerIndex.findBoundariesIn(start, end)
         assert.deepEqual(containingStart, expectedContainingMarkerIds, seedMessage)
+
         assert.equal(boundaries.length, expectedBoundaries.length, seedMessage)
         for (let i = 0; i < boundaries.length; i++) {
           const actual = boundaries[i]

--- a/test/js/marker-index.test.js
+++ b/test/js/marker-index.test.js
@@ -2,6 +2,7 @@ const Random = require('random-seed')
 const {traverse, traversalDistance, compare, isZero, max, format: formatPoint} = require('./helpers/point-helpers')
 const {assert} = require('chai')
 const {MarkerIndex} = require('../..')
+const MAX_INT32 = 4294967296
 
 describe('MarkerIndex', () => {
   it('maintains correct marker positions during randomized insertions and mutations', function () {
@@ -9,8 +10,9 @@ describe('MarkerIndex', () => {
 
     let seed, seedMessage, random, markerIndex, markers, idCounter
 
+    const generateSeed = Random.create()
     for (let i = 0; i < 1000; i++) {
-      seed = Date.now()
+      seed = generateSeed(MAX_INT32)
       seedMessage = `Random Seed: ${seed}`
       random = new Random(seed)
       markerIndex = new MarkerIndex(seed)


### PR DESCRIPTION
This pull request adds a new method to marker-index which will allow us to efficiently query boundaries in a given point range. A boundary is a position in the index where a marker starts or ends. Multiple markers starting and/or ending at the same position describe only one boundary.

This new method returns an object containing all the boundaries in the specified point range, and an array of marker ids that overlap the specified start position. For example:

```js
{
  containingStart: [1, 2, 3, 4],
  boundaries: [
    {position: {row: 0, column: 1}, starting: new Set([5, 6]), ending: new Set()},
    {position: {row: 1, column: 0}, starting: new Set(), ending: new Set([5])}
    {position: {row: 2, column: 0}, starting: new Set(), ending: new Set([6])}
  ]
}
```

This will be used in Atom to expose text decorations to a display layer.

What's missing:
  * [x] Ensure emscripten bindings work. Right now I am getting an `UnboundTypeError: Cannot call MarkerIndex.findBoundariesIn due to unbound types: NSt3__26vectorIjNS_9allocatorIjEEEE, NSt3__26vectorIN11MarkerIndex8BoundaryENS_9allocatorIS2_EEEE`.

/cc: @nathansobo @maxbrunsfeld 