### PR TITLE
Replace MarkerIndex.findBoundariesIn with findBoundariesAfter taking a max count

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
 } else {
   try {
     module.exports = require('./build/Release/superstring.node')
-  } catch (e) {
-    module.exports = require('./build/Debug/superstring.node')
+  } catch (e1) {
+    try {
+      module.exports = require('./build/Debug/superstring.node')
+    } catch (e2) {
+      throw e1
+    }
   }
 }

--- a/src/bindings/em/marker-index.cc
+++ b/src/bindings/em/marker-index.cc
@@ -23,7 +23,7 @@ EMSCRIPTEN_BINDINGS(MarkerIndex) {
     .function("findStartingAt", WRAP(&MarkerIndex::find_starting_at))
     .function("findEndingIn", WRAP(&MarkerIndex::find_ending_in))
     .function("findEndingAt", WRAP(&MarkerIndex::find_ending_at))
-    .function("findBoundariesIn", WRAP(&MarkerIndex::find_boundaries_in))
+    .function("findBoundariesAfter", WRAP(&MarkerIndex::find_boundaries_after))
     .function("dump", WRAP(&MarkerIndex::dump));
 
   emscripten::value_object<MarkerIndex::SpliceResult>("SpliceResult")

--- a/src/bindings/marker-index-wrapper.cc
+++ b/src/bindings/marker-index-wrapper.cc
@@ -53,7 +53,7 @@ void MarkerIndexWrapper::init(Local<Object> exports) {
                           Nan::New<FunctionTemplate>(find_starting_at));
   prototype_template->Set(Nan::New<String>("findEndingIn").ToLocalChecked(), Nan::New<FunctionTemplate>(find_ending_in));
   prototype_template->Set(Nan::New<String>("findEndingAt").ToLocalChecked(), Nan::New<FunctionTemplate>(find_ending_at));
-  prototype_template->Set(Nan::New<String>("findBoundariesIn").ToLocalChecked(), Nan::New<FunctionTemplate>(find_boundaries_in));
+  prototype_template->Set(Nan::New<String>("findBoundariesAfter").ToLocalChecked(), Nan::New<FunctionTemplate>(find_boundaries_after));
   prototype_template->Set(Nan::New<String>("dump").ToLocalChecked(), Nan::New<FunctionTemplate>(dump));
 
   start_string.Reset(Nan::Persistent<String>(Nan::New("start").ToLocalChecked()));
@@ -329,14 +329,18 @@ void MarkerIndexWrapper::find_ending_at(const Nan::FunctionCallbackInfo<Value> &
   }
 }
 
-void MarkerIndexWrapper::find_boundaries_in(const Nan::FunctionCallbackInfo<Value> &info) {
+void MarkerIndexWrapper::find_boundaries_after(const Nan::FunctionCallbackInfo<Value> &info) {
   MarkerIndexWrapper *wrapper = Nan::ObjectWrap::Unwrap<MarkerIndexWrapper>(info.This());
 
   optional<Point> start = PointWrapper::point_from_js(info[0]);
-  optional<Point> end = PointWrapper::point_from_js(info[1]);
+  optional<size_t> max_count;
+  Local<Integer> js_max_count;
+  if (Nan::To<Integer>(info[1]).ToLocal(&js_max_count)) {
+    max_count = js_max_count->NumberValue();
+  }
 
-  if (start && end) {
-    MarkerIndex::BoundaryQueryResult result = wrapper->marker_index.find_boundaries_in(*start, *end);
+  if (start && max_count) {
+    MarkerIndex::BoundaryQueryResult result = wrapper->marker_index.find_boundaries_after(*start, *max_count);
     Local<Object> js_result = Nan::New<Object>();
     js_result->Set(Nan::New(containing_start_string), marker_ids_vector_to_js(result.containing_start));
 

--- a/src/bindings/marker-index-wrapper.h
+++ b/src/bindings/marker-index-wrapper.h
@@ -33,7 +33,7 @@ private:
   static void find_starting_at(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_ending_in(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_ending_at(const Nan::FunctionCallbackInfo<v8::Value> &info);
-  static void find_boundaries_in(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void find_boundaries_after(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void dump(const Nan::FunctionCallbackInfo<v8::Value> &info);
   MarkerIndexWrapper(v8::Local<v8::Number> seed);
   MarkerIndex marker_index;

--- a/src/core/marker-index.cc
+++ b/src/core/marker-index.cc
@@ -210,7 +210,7 @@ void MarkerIndex::Iterator::find_ending_in(const Point &start, const Point &end,
   }
 }
 
-void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerIndex::BoundaryQueryResult *result) {
+void MarkerIndex::Iterator::find_boundaries_after(Point start, size_t max_count, MarkerIndex::BoundaryQueryResult *result) {
   reset();
   if (!current_node) return;
 
@@ -257,7 +257,7 @@ void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerInd
   );
 
   if (current_node_position < start) move_to_successor();
-  while (current_node && current_node_position < end) {
+  while (current_node && max_count > 0) {
     cache_node_position();
     result->boundaries.push_back({
       current_node_position,
@@ -265,6 +265,7 @@ void MarkerIndex::Iterator::find_boundaries_in(Point start, Point end, MarkerInd
       current_node->end_marker_ids
     });
     move_to_successor();
+    max_count--;
   }
 }
 
@@ -700,9 +701,9 @@ flat_set<MarkerIndex::MarkerId> MarkerIndex::find_ending_at(Point position) {
   return find_ending_in(position, position);
 }
 
-MarkerIndex::BoundaryQueryResult MarkerIndex::find_boundaries_in(Point start, Point end) {
+MarkerIndex::BoundaryQueryResult MarkerIndex::find_boundaries_after(Point start, size_t max_count) {
   BoundaryQueryResult result;
-  iterator.find_boundaries_in(start, end, &result);
+  iterator.find_boundaries_after(start, max_count, &result);
   return result;
 }
 

--- a/src/core/marker-index.h
+++ b/src/core/marker-index.h
@@ -50,7 +50,7 @@ public:
   flat_set<MarkerId> find_starting_at(Point position);
   flat_set<MarkerId> find_ending_in(Point start, Point end);
   flat_set<MarkerId> find_ending_at(Point position);
-  BoundaryQueryResult find_boundaries_in(Point start, Point end);
+  BoundaryQueryResult find_boundaries_after(Point start, size_t max_count);
 
   std::unordered_map<MarkerId, Range> dump();
 
@@ -83,7 +83,7 @@ private:
     void find_contained_in(const Point &start, const Point &end, flat_set<MarkerId> *result);
     void find_starting_in(const Point &start, const Point &end, flat_set<MarkerId> *result);
     void find_ending_in(const Point &start, const Point &end, flat_set<MarkerId> *result);
-    void find_boundaries_in(const Point start, const Point end, BoundaryQueryResult *result);
+    void find_boundaries_after(Point start, size_t max_count, BoundaryQueryResult *result);
     std::unordered_map<MarkerId, Range> dump();
 
   private:

--- a/test/js/marker-index.test.js
+++ b/test/js/marker-index.test.js
@@ -43,7 +43,7 @@ describe('MarkerIndex', () => {
         testFindEndingIn,
         testFindStartingAt,
         testFindEndingAt,
-        testFindBoundariesIn
+        testFindBoundariesAfter
       ].sort((a, b) => random.intBetween(-1, 1))
 
       verifications.forEach(verification => verification())
@@ -283,9 +283,10 @@ describe('MarkerIndex', () => {
       }
     }
 
-    function testFindBoundariesIn () {
+    function testFindBoundariesAfter () {
       for (let i = 0; i < 10; i++) {
-        const [start, end] = getRange()
+        const start = {row: random(100), column: random(100)}
+        const maxCount = random(20)
 
         const expectedContainingMarkerIds = []
         let expectedBoundaries = []
@@ -295,7 +296,7 @@ describe('MarkerIndex', () => {
             expectedContainingMarkerIds.push(marker.id)
           }
 
-          if (compare(marker.start, start) >= 0 && compare(marker.start, end) < 0) {
+          if (compare(marker.start, start) >= 0) {
             expectedBoundaries.push({
               position: marker.start,
               starting: new Set([marker.id]),
@@ -303,7 +304,7 @@ describe('MarkerIndex', () => {
             })
           }
 
-          if (compare(marker.end, start) >= 0 && compare(marker.end, end) < 0) {
+          if (compare(marker.end, start) >= 0) {
             expectedBoundaries.push({
               position: marker.end,
               starting: new Set(),
@@ -323,8 +324,9 @@ describe('MarkerIndex', () => {
           }
           return acc
         }, [])
+        expectedBoundaries = expectedBoundaries.slice(0, maxCount)
 
-        const {containingStart, boundaries} = markerIndex.findBoundariesIn(start, end)
+        const {containingStart, boundaries} = markerIndex.findBoundariesAfter(start, maxCount)
         assert.deepEqual(containingStart, expectedContainingMarkerIds, seedMessage)
 
         assert.equal(boundaries.length, expectedBoundaries.length, seedMessage)


### PR DESCRIPTION
When querying marker boundaries to implement `MarkerTextDecorationLayerIterator`, we know where we're starting based on calls to `seek`, but we don't really know where we're ending. The following solutions to this problem don't really work:

* The original plan of fetching a "window" breaks down when there are large gaps in the markers. When we call `moveToSuccessor` on the iterator, the contract is for it to move to the successor, regardless of how far away it is. With the spatial query approach we could potentially need to query N windows up to the end of the buffer looking for a successor that may or may not exist.
* We could specify a visible buffer row range on the display layer, but in the presence of large folds this could end up spanning many more rows than we actually render on screen. Needing to know about folded areas would introduce a lot of complexity, and this is part of why we used iterators to begin with.

For now, the easiest solution is to fetch a maximum count of boundaries rather than fetching boundaries in a given range. The cost of this operation really scales with the number of boundaries we are fetching rather than where they are located spatially, so we can set a limit that is always affordable. If there is a large folded area, we'll still be able to skip over most of it by seeking the iterator to the end of the fold and fetching another N markers there.

/cc @as-cii 