### PR TITLE
Reduce peak memory usage when loading files from disk

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,6 @@
             "type": "static_library",
             "dependencies": [
                 "./vendor/pcre/pcre.gyp:pcre",
-                "superstring_core_diff"
             ],
             "sources": [
                 "src/core/encoding-conversion.cc",
@@ -38,6 +37,8 @@
                 "src/core/text.cc",
                 "src/core/text-buffer.cc",
                 "src/core/text-slice.cc",
+                "src/core/text-diff.cc",
+                "src/core/libmba-diff.cc",
             ],
             "conditions": [
                 ['OS=="mac"', {
@@ -58,24 +59,7 @@
                     ]
                 }],
             ],
-        },
-
-        # This file is built as a separate target because the library that it
-        # uses, diff-match-patch, requires exceptions to be enabled.
-        {
-            "target_name": "superstring_core_diff",
-            "type": "static_library",
-            "include_dirs": [
-                "./vendor/diff-match-patch"
-            ],
-            "sources": [
-                "src/core/text-diff.cc",
-            ],
-            'xcode_settings': {
-                "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-            },
-            "cflags_cc!": ["-fno-exceptions"],
-        },
+        }
     ],
 
     "variables": {

--- a/src/core/libmba-diff.cc
+++ b/src/core/libmba-diff.cc
@@ -1,0 +1,297 @@
+/*
+ * This file is based on `diff.c` from `libmba`
+ * http://www.ioplex.com/~miallen/libmba
+ *
+ * It has been modified in the following ways:
+ *
+ * 1. The parameters have been changed from `void *` to `uint16_t *`;
+ *    the algorithm is now hard-coded to work on UTF16 input.
+ * 2. The edit script and the internal buffer are now stored as `std::vector`
+ *    instead of `libmba`'s custom C array type `varray`. This change speeds up
+ *    the algorithm significantly and eliminates a dependency on other `libmba`
+ *    components.
+ * 3. Some optional parameters to the function have been removed.
+ * 4. The whitespace has been normalized.
+ */
+
+/* diff - compute a shortest edit script (SES) given two sequences
+ * Copyright (c) 2004 Michael B. Allen <mba2000 ioplex.com>
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* This algorithm is basically Myers' solution to SES/LCS with
+ * the Hirschberg linear space refinement as described in the
+ * following publication:
+ *
+ *   E. Myers, ``An O(ND) Difference Algorithm and Its Variations,''
+ *   Algorithmica 1, 2 (1986), 251-266.
+ *   http://www.cs.arizona.edu/people/gene/PAPERS/diff.ps
+ *
+ * This is the same algorithm used by GNU diff(1).
+ */
+
+#include "libmba-diff.h"
+#include <stdlib.h>
+#include <limits.h>
+#include <errno.h>
+#include <vector>
+
+using std::vector;
+
+#define FV(k) _v(ctx, (k), 0)
+#define RV(k) _v(ctx, (k), 1)
+
+struct _ctx {
+  vector<int> buf;
+  vector<diff_edit> *ses;
+  int dmax;
+};
+
+struct middle_snake {
+  int x, y, u, v;
+};
+
+static void _setv(struct _ctx *ctx, int k, int r, int val) {
+  /* Pack -N to N into 0 to N * 2 */
+  unsigned j = k <= 0 ? -k * 4 + r : k * 4 + (r - 2);
+  if (ctx->buf.size() < j + 1) {
+    ctx->buf.resize(j + 1);
+  }
+  ctx->buf[j] = val;
+}
+
+static int _v(struct _ctx *ctx, int k, int r) {
+  int j = k <= 0 ? -k * 4 + r : k * 4 + (r - 2);
+  return ctx->buf[j];
+}
+
+static int _find_middle_snake(
+  const uint16_t *a, int aoff, int n,
+  const uint16_t *b, int boff, int m,
+  struct _ctx *ctx, struct middle_snake *ms
+) {
+  int delta, odd, mid, d;
+
+  delta = n - m;
+  odd = delta & 1;
+  mid = (n + m) / 2;
+  mid += odd;
+
+  _setv(ctx, 1, 0, 0);
+  _setv(ctx, delta - 1, 1, n);
+
+  for (d = 0; d <= mid; d++) {
+    int k, x, y;
+
+    if ((2 * d - 1) >= ctx->dmax) {
+      return ctx->dmax;
+    }
+
+    for (k = d; k >= -d; k -= 2) {
+      if (k == -d || (k != d && FV(k - 1) < FV(k + 1))) {
+        x = FV(k + 1);
+      } else {
+        x = FV(k - 1) + 1;
+      }
+      y = x - k;
+
+      ms->x = x;
+      ms->y = y;
+      const uint16_t *a0 = a + aoff;
+      const uint16_t *b0 = b + boff;
+      while (x < n && y < m && a0[x] == b0[y]) {
+        x++; y++;
+      }
+      _setv(ctx, k, 0, x);
+
+      if (odd && k >= (delta - (d - 1)) && k <= (delta + (d - 1))) {
+        if (x >= RV(k)) {
+          ms->u = x;
+          ms->v = y;
+          return 2 * d - 1;
+        }
+      }
+    }
+
+    for (k = d; k >= -d; k -= 2) {
+      int kr = (n - m) + k;
+
+      if (k == d || (k != -d && RV(kr - 1) < RV(kr + 1))) {
+        x = RV(kr - 1);
+      } else {
+        x = RV(kr + 1) - 1;
+      }
+      y = x - kr;
+
+      ms->u = x;
+      ms->v = y;
+      const uint16_t *a0 = a + aoff;
+      const uint16_t *b0 = b + boff;
+      while (x > 0 && y > 0 && a0[x - 1] == b0[y - 1]) {
+        x--; y--;
+      }
+      _setv(ctx, kr, 1, x);
+
+      if (!odd && kr >= -d && kr <= d) {
+        if (x <= FV(kr)) {
+          ms->x = x;
+          ms->y = y;
+          return 2 * d;
+        }
+      }
+    }
+  }
+
+  errno = EFAULT;
+
+  return -1;
+}
+
+static void _edit(struct _ctx *ctx, int op, int off, int len) {
+  // Add an edit to the SES (or coalesce if the op is the same)
+  auto *e = &ctx->ses->back();
+  if (e->op != op) {
+    if (e->op) {
+      ctx->ses->push_back(diff_edit{});
+      e = &ctx->ses->back();
+    }
+    e->op = op;
+    e->off = off;
+    e->len = len;
+  } else {
+    e->len += len;
+  }
+}
+
+static int _ses(
+  const uint16_t *a, int aoff, int n,
+  const uint16_t *b, int boff, int m,
+  struct _ctx *ctx
+) {
+  struct middle_snake ms;
+  int d;
+
+  if (n == 0) {
+    _edit(ctx, DIFF_INSERT, boff, m);
+    d = m;
+  } else if (m == 0) {
+    _edit(ctx, DIFF_DELETE, aoff, n);
+    d = n;
+  } else {
+    /* Find the middle "snake" around which we
+     * recursively solve the sub-problems.
+     */
+    d = _find_middle_snake(a, aoff, n, b, boff, m, ctx, &ms);
+    if (d == -1) {
+      return -1;
+    } else if (d >= ctx->dmax) {
+      return ctx->dmax;
+    } else if (ctx->ses == NULL) {
+      return d;
+    } else if (d > 1) {
+      if (_ses(a, aoff, ms.x, b, boff, ms.y, ctx) == -1) {
+        return -1;
+      }
+
+      _edit(ctx, DIFF_MATCH, aoff + ms.x, ms.u - ms.x);
+
+      aoff += ms.u;
+      boff += ms.v;
+      n -= ms.u;
+      m -= ms.v;
+      if (_ses(a, aoff, n, b, boff, m, ctx) == -1) {
+        return -1;
+      }
+    } else {
+      int x = ms.x;
+      int u = ms.u;
+
+     /* There are only 4 base cases when the
+      * edit distance is 1.
+      *
+      * n > m   m > n
+      *
+      *   -       |
+      *    \       \    x != u
+      *     \       \
+      *
+      *   \       \
+      *    \       \    x == u
+      *     -       |
+      */
+      if (m > n) {
+        if (x == u) {
+          _edit(ctx, DIFF_MATCH, aoff, n);
+          _edit(ctx, DIFF_INSERT, boff + (m - 1), 1);
+        } else {
+          _edit(ctx, DIFF_INSERT, boff, 1);
+          _edit(ctx, DIFF_MATCH, aoff, n);
+        }
+      } else {
+        if (x == u) {
+          _edit(ctx, DIFF_MATCH, aoff, m);
+          _edit(ctx, DIFF_DELETE, aoff + (n - 1), 1);
+        } else {
+          _edit(ctx, DIFF_DELETE, aoff, 1);
+          _edit(ctx, DIFF_MATCH, aoff + 1, m);
+        }
+      }
+    }
+  }
+
+  return d;
+}
+
+int diff(const uint16_t *a, int aoff, int n, const uint16_t *b, int boff, int m,
+         int dmax, vector<diff_edit> *ses) {
+  int d, x, y;
+
+  struct _ctx ctx;
+  ctx.ses = ses;
+  ctx.dmax = dmax ? dmax : INT_MAX;
+
+  ses->push_back(diff_edit{0, 0, 0});
+
+ /* The _ses function assumes the SES will begin or end with a delete
+  * or insert. The following will insure this is true by eating any
+  * beginning matches. This is also a quick to process sequences
+  * that match entirely.
+  */
+  x = y = 0;
+  const uint16_t *a0 = a + aoff;
+  const uint16_t *b0 = b + boff;
+  while (x < n && y < m && a0[x] == b0[y]) {
+    x++; y++;
+  }
+  _edit(&ctx, DIFF_MATCH, aoff, x);
+
+  if ((d = _ses(a, aoff + x, n - x, b, boff + y, m - y, &ctx)) == -1) {
+    return -1;
+  }
+
+  if (ses->front().op == 0) {
+    ses->pop_back();
+  }
+
+  return d;
+}
+

--- a/src/core/libmba-diff.h
+++ b/src/core/libmba-diff.h
@@ -1,0 +1,25 @@
+#ifndef MBA_DIFF_H_
+#define MBA_DIFF_H_
+
+#include <stdint.h>
+#include <vector>
+
+typedef enum {
+  DIFF_MATCH = 1,
+  DIFF_DELETE,
+  DIFF_INSERT
+} diff_op;
+
+struct diff_edit {
+  short op;
+  int off; /* off into s1 if MATCH or DELETE but s2 if INSERT */
+  int len;
+};
+
+int diff(
+  const uint16_t *a, int aoff, int n,
+  const uint16_t *b, int boff, int m,
+  int dmax, std::vector<diff_edit> *ses
+);
+
+#endif  // MBA_DIFF_H_

--- a/src/core/libmba-diff.h
+++ b/src/core/libmba-diff.h
@@ -11,14 +11,14 @@ typedef enum {
 } diff_op;
 
 struct diff_edit {
-  short op;
-  int off; /* off into s1 if MATCH or DELETE but s2 if INSERT */
-  int len;
+  diff_op op;
+  uint32_t off; /* off into s1 if MATCH or DELETE but s2 if INSERT */
+  uint32_t len;
 };
 
 int diff(
-  const uint16_t *a, int aoff, int n,
-  const uint16_t *b, int boff, int m,
+  const uint16_t *old_text, uint32_t old_length,
+  const uint16_t *new_text, uint32_t new_length,
   int dmax, std::vector<diff_edit> *ses
 );
 

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -412,16 +412,36 @@ TextBuffer::TextBuffer(const std::u16string &text) :
   TextBuffer{String{text.begin(), text.end()}} {}
 
 void TextBuffer::reset(Text &&new_base_text) {
-  if (!top_layer->previous_layer && top_layer->snapshot_count == 0) {
-    top_layer->extent_ = new_base_text.extent();
-    top_layer->size_ = new_base_text.size();
-    top_layer->text = move(new_base_text);
-    top_layer->patch.clear();
-    top_layer->uses_patch = false;
-  } else {
+  bool has_snapshot = false;
+  auto layer = top_layer;
+  while (layer) {
+    if (layer->snapshot_count > 0) {
+      has_snapshot = true;
+      break;
+    }
+    layer = layer->previous_layer;
+  }
+
+  if (has_snapshot) {
     set_text(String(new_base_text.content));
     flush_changes();
+    return;
   }
+
+  layer = top_layer->previous_layer;
+  while (layer) {
+    Layer *previous_layer = layer->previous_layer;
+    delete layer;
+    layer = previous_layer;
+  }
+
+  top_layer->extent_ = new_base_text.extent();
+  top_layer->size_ = new_base_text.size();
+  top_layer->text = move(new_base_text);
+  top_layer->patch.clear();
+  top_layer->uses_patch = false;
+  base_layer = top_layer;
+  top_layer->previous_layer = nullptr;
 }
 
 Patch TextBuffer::get_inverted_changes(const Snapshot *snapshot) const {

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -423,7 +423,7 @@ void TextBuffer::reset(Text &&new_base_text) {
   }
 
   if (has_snapshot) {
-    set_text(String(new_base_text.content));
+    set_text(move(new_base_text.content));
     flush_changes();
     return;
   }

--- a/src/core/text-diff.cc
+++ b/src/core/text-diff.cc
@@ -16,7 +16,7 @@ static Point previous_column(Point position) {
   return position;
 }
 
-static int MAX_EDIT_DISTANCE = 10 * 1024;
+static int MAX_EDIT_DISTANCE = 1024;
 
 Patch text_diff(const Text &old_text, const Text &new_text) {
   Patch result;

--- a/src/core/text-diff.cc
+++ b/src/core/text-diff.cc
@@ -28,10 +28,8 @@ Patch text_diff(const Text &old_text, const Text &new_text) {
 
   if (diff(
     old_text.content.data(),
-    0,
     old_text.content.size(),
     new_text.content.data(),
-    0,
     new_text.content.size(),
     MAX_EDIT_DISTANCE,
     &edit_script

--- a/src/core/text-diff.cc
+++ b/src/core/text-diff.cc
@@ -1,29 +1,14 @@
 #include "text-diff.h"
-#include "diff_match_patch.h"
+#include "libmba-diff.h"
 #include "text-slice.h"
+#include <vector>
 #include <string.h>
-#include <string>
+#include <ostream>
 #include <cassert>
 
 using std::move;
-using std::u16string;
-
-struct StringAdapterTraits {
-  static bool is_alnum(char16_t c) { return std::iswalnum(c); }
-  static bool is_digit(char16_t c) { return std::iswdigit(c); }
-  static bool is_space(char16_t c) { return std::iswspace(c); }
-  static wchar_t to_wchar(char16_t c) { return c; }
-  static char16_t from_wchar(wchar_t c) { return c; }
-  static const char16_t eol = '\n';
-  static const char16_t tab = '\t';
-
-  // These functions are not used when computing diffs; the diff-match-patch
-  // library uses them in functions that we don't call.
-  static u16string cs(const wchar_t* s) { assert(false); return u16string(); }
-  static int to_int(const char16_t* s) { assert(false); return 0; }
-};
-
-using DiffBuilder = diff_match_patch<u16string, StringAdapterTraits>;
+using std::ostream;
+using std::vector;
 
 static Point previous_column(Point position) {
   assert(position.column > 0);
@@ -31,35 +16,39 @@ static Point previous_column(Point position) {
   return position;
 }
 
+static int MAX_EDIT_DISTANCE = 10 * 1024;
+
 Patch text_diff(const Text &old_text, const Text &new_text) {
   Patch result;
   Text empty;
   Text cr{u"\r"};
   Text lf{u"\n"};
 
-  // When a buffer is intially loaded, this function is called with an empty
-  // `old_text`. In that case, we can avoid the overhead of converting the text
-  // to a u16string and back in order to compute the diff.
-  if (old_text.empty()) {
-    result.splice(Point(), Point(), new_text.extent(), empty, new_text);
+  vector<diff_edit> edit_script;
+
+  if (diff(
+    old_text.content.data(),
+    0,
+    old_text.content.size(),
+    new_text.content.data(),
+    0,
+    new_text.content.size(),
+    MAX_EDIT_DISTANCE,
+    &edit_script
+  ) == -1) {
+    result.splice(Point(), old_text.extent(), new_text.extent(), old_text, new_text);
     return result;
   }
-
-  u16string old_string(old_text.content.begin(), old_text.content.end());
-  u16string new_string(new_text.content.begin(), new_text.content.end());
-
-  DiffBuilder diff_builder;
-  diff_builder.Diff_Timeout = 5;
-  DiffBuilder::Diffs diffs = diff_builder.diff_main(old_string, new_string);
 
   size_t old_offset = 0;
   size_t new_offset = 0;
   Point old_position;
   Point new_position;
 
-  for (DiffBuilder::Diff &diff : diffs) {
-    switch (diff.operation) {
-      case DiffBuilder::Operation::EQUAL:
+  for (struct diff_edit &edit : edit_script) {
+    switch (edit.op) {
+      case DIFF_MATCH:
+        if (edit.len == 0) continue;
 
         // If the previous change ended between a CR and an LF, then expand
         // that change downward to include the LF.
@@ -73,8 +62,8 @@ Patch text_diff(const Text &old_text, const Text &new_text) {
           new_position.column = 0;
         }
 
-        old_offset += diff.text.size();
-        new_offset += diff.text.size();
+        old_offset += edit.len;
+        new_offset += edit.len;
         old_position = old_text.position_for_offset(old_offset, 0, false);
         new_position = new_text.position_for_offset(new_offset, 0, false);
 
@@ -87,18 +76,20 @@ Patch text_diff(const Text &old_text, const Text &new_text) {
         }
         break;
 
-      case DiffBuilder::Operation::DELETE: {
-        Text deleted_text{move(diff.text)};
-        old_offset += diff.text.size();
+      case DIFF_DELETE: {
+        uint32_t deletion_end = old_offset + edit.len;
+        Text deleted_text{old_text.begin() + old_offset, old_text.begin() + deletion_end};
+        old_offset = deletion_end;
         Point next_old_position = old_text.position_for_offset(old_offset, 0, false);
         result.splice(new_position, next_old_position.traversal(old_position), Point(), deleted_text, empty);
         old_position = next_old_position;
         break;
       }
 
-      case DiffBuilder::Operation::INSERT: {
-        Text inserted_text{move(diff.text)};
-        new_offset += diff.text.size();
+      case DIFF_INSERT: {
+        uint32_t insertion_end = new_offset + edit.len;
+        Text inserted_text{new_text.begin() + new_offset, new_text.begin() + insertion_end};
+        new_offset = insertion_end;
         Point next_new_position = new_text.position_for_offset(new_offset, 0, false);
         result.splice(new_position, Point(), next_new_position.traversal(new_position), empty, inserted_text);
         new_position = next_new_position;

--- a/src/core/text.cc
+++ b/src/core/text.cc
@@ -10,9 +10,9 @@ using String = Text::String;
 
 Text::Text() : line_offsets{0} {}
 
-Text::Text(vector<uint16_t> &&content) : content{content}, line_offsets{0} {
-  for (uint32_t offset = 0, size = content.size(); offset < size; offset++) {
-    if (content[offset] == '\n') {
+Text::Text(vector<uint16_t> &&content) : content{move(content)}, line_offsets{0} {
+  for (uint32_t offset = 0, size = this->content.size(); offset < size; offset++) {
+    if (this->content[offset] == '\n') {
       line_offsets.push_back(offset + 1);
     }
   }

--- a/test/native/text-diff-test.cc
+++ b/test/native/text-diff-test.cc
@@ -63,7 +63,7 @@ TEST_CASE("text_diff - randomized changes") {
     Generator rand(seed);
     cout << "seed: " << seed << "\n";
 
-    Text old_text{get_random_string(rand, 10)};
+    Text old_text{get_random_string(rand, 100)};
     Text new_text = old_text;
 
     // cout << "extent: " << new_text.extent() << " text:\n" << new_text << "\n\n";

--- a/test/native/text-diff-test.cc
+++ b/test/native/text-diff-test.cc
@@ -56,6 +56,54 @@ TEST_CASE("text_diff - single line") {
   }));
 }
 
+TEST_CASE("text_diff - old text is empty") {
+  Text old_text{u""};
+  Text new_text{u"abc\ndef\nghi\njkl\n"};
+
+  Patch patch = text_diff(old_text, new_text);
+
+  REQUIRE(patch.get_changes() == vector<Change>({
+    Change{
+      Point{0, 0}, Point{0, 0},
+      Point{0, 0}, Point{4, 0},
+      get_text(u"").get(), get_text(u"abc\ndef\nghi\njkl\n").get(),
+      0, 0, 0
+    },
+  }));
+}
+
+TEST_CASE("text_diff - old text is a prefix of new text") {
+  Text old_text{u"abc\ndef\n"};
+  Text new_text{u"abc\ndef\nghi\njkl\n"};
+
+  Patch patch = text_diff(old_text, new_text);
+
+  REQUIRE(patch.get_changes() == vector<Change>({
+    Change{
+      Point{2, 0}, Point{2, 0},
+      Point{2, 0}, Point{4, 0},
+      get_text(u"").get(), get_text(u"ghi\njkl\n").get(),
+      0, 0, 0
+    },
+  }));
+}
+
+TEST_CASE("text_diff - old text is a suffix of new text") {
+  Text old_text{u"ghi\njkl\n"};
+  Text new_text{u"abc\ndef\nghi\njkl\n"};
+
+  Patch patch = text_diff(old_text, new_text);
+
+  REQUIRE(patch.get_changes() == vector<Change>({
+    Change{
+      Point{0, 0}, Point{0, 0},
+      Point{0, 0}, Point{2, 0},
+      get_text(u"").get(), get_text(u"abc\ndef\n").get(),
+      0, 0, 0
+    },
+  }));
+}
+
 TEST_CASE("text_diff - randomized changes") {
   auto t = time(nullptr);
   for (uint i = 0; i < 100; i++) {


### PR DESCRIPTION
After https://github.com/atom/atom/pull/14435 landed, we started seeing Atom crash on 32-bit windows systems when large files changed on disk. This would be observable both when saving the file in Atom and when the file changed on disk outside of Atom.

@damieng and I determined that the crashes were due to `bad_alloc` exceptions being thrown at various times when loading the new text from disk and diffing it with the old text. This PR optimizes the peak memory usage on that code path in a few ways.

The diff algorithm we were using, a port of Google's `diff-match-patch` library, used `std::strings` throughout the library. Each of these objects contained a copy of some subset of the text. The library is very fast, but allocates too much memory to be suitable diffing of large files in Atom. We now use a C implementation of Myer's diff from a library called [libmba](http://www.ioplex.com/~miallen/libmba). I've checked this code directly into this repository and made some modifications to it to make it work efficiently w/ UTF16 text.

I also discovered two other places where we were accidentally creating temporary copies of a file's content.

/cc @ungb @damieng