### PR TITLE
Configure PCRE to treat CRLF as a line ending

### DIFF
--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -372,6 +372,15 @@ TEST_CASE("TextBuffer::find_all") {
   }));
 }
 
+TEST_CASE("TextBuffer::find_all - CRLF line endings") {
+  TextBuffer buffer{u"abc\ndef\r\nghi"};
+  REQUIRE(buffer.find_all(Regex(u"\\w$", nullptr)) == vector<Range>({
+    Range{Point{0, 2}, Point{0, 3}},
+    Range{Point{1, 2}, Point{1, 3}},
+    Range{Point{2, 2}, Point{2, 3}},
+  }));
+}
+
 struct SnapshotData {
   Text base_text;
   String text;

--- a/vendor/pcre/include/config.h
+++ b/vendor/pcre/include/config.h
@@ -199,7 +199,7 @@ sure both macros are undefined; an emulation function will then be used. */
    at run time. The valid values are 1 (CR), 2 (LF), 3 (CRLF), 4 (ANY), and 5
    (ANYCRLF). */
 #ifndef NEWLINE_DEFAULT
-#define NEWLINE_DEFAULT 2
+#define NEWLINE_DEFAULT 4
 #endif
 
 /* Name of package */


### PR DESCRIPTION
Fixes https://github.com/atom/whitespace/issues/158