### PR TITLE
Add TextBuffer.getLineCount

### DIFF
--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -52,6 +52,10 @@ static uint32_t character_index_for_position(TextBuffer &buffer, Point position)
   return buffer.clip_position(position).offset;
 }
 
+static uint32_t get_line_count(TextBuffer &buffer) {
+  return buffer.extent().row + 1;
+}
+
 static Point position_for_character_index(TextBuffer &buffer, long index) {
   return index < 0 ?
     Point{0, 0} :
@@ -68,6 +72,7 @@ EMSCRIPTEN_BINDINGS(TextBuffer) {
     .function("setTextInRange", WRAP_OVERLOAD(&TextBuffer::set_text_in_range, void (TextBuffer::*)(Range, Text::String &&)))
     .function("getLength", &TextBuffer::size)
     .function("getExtent", &TextBuffer::extent)
+    .function("getLineCount", get_line_count)
     .function("reset", WRAP(&TextBuffer::reset))
     .function("lineLengthForRow", WRAP(&TextBuffer::line_length_for_row))
     .function("lineEndingForRow", line_ending_for_row)

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -108,6 +108,7 @@ void TextBufferWrapper::init(Local<Object> exports) {
   prototype_template->Set(Nan::New("delete").ToLocalChecked(), Nan::New<FunctionTemplate>(noop));
   prototype_template->Set(Nan::New("getLength").ToLocalChecked(), Nan::New<FunctionTemplate>(get_length));
   prototype_template->Set(Nan::New("getExtent").ToLocalChecked(), Nan::New<FunctionTemplate>(get_extent));
+  prototype_template->Set(Nan::New("getLineCount").ToLocalChecked(), Nan::New<FunctionTemplate>(get_line_count));
   prototype_template->Set(Nan::New("getTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text_in_range));
   prototype_template->Set(Nan::New("setTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(set_text_in_range));
   prototype_template->Set(Nan::New("getText").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text));
@@ -154,6 +155,11 @@ void TextBufferWrapper::get_length(const Nan::FunctionCallbackInfo<Value> &info)
 void TextBufferWrapper::get_extent(const Nan::FunctionCallbackInfo<Value> &info) {
   auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
   info.GetReturnValue().Set(PointWrapper::from_point(text_buffer.extent()));
+}
+
+void TextBufferWrapper::get_line_count(const Nan::FunctionCallbackInfo<Value> &info) {
+  auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
+  info.GetReturnValue().Set(Nan::New(text_buffer.extent().row + 1));
 }
 
 void TextBufferWrapper::get_text_in_range(const Nan::FunctionCallbackInfo<Value> &info) {

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -13,6 +13,7 @@ private:
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_length(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_extent(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void get_line_count(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_text(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_text_in_range(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void set_text(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -643,12 +643,17 @@ describe('TextBuffer', () => {
     })
   })
 
-  describe('.getLength and .getExtent', () => {
+  describe('.getLength, .getExtent, and .getLineCount', () => {
     it('returns the total length and total extent of the text', () => {
       const buffer = new TextBuffer()
+      assert.equal(buffer.getLength(), 0)
+      assert.deepEqual(buffer.getExtent(), Point(0, 0))
+      assert.equal(buffer.getLineCount(), 1)
+
       buffer.setText('abc\r\ndefg\n\r\nhijkl')
       assert.equal(buffer.getLength(), buffer.getText().length)
       assert.deepEqual(buffer.getExtent(), Point(3, 5))
+      assert.equal(buffer.getLineCount(), 4)
     })
   })
 


### PR DESCRIPTION
Computing the line count using `.getExtent` is unnecessarily expensive, because it allocates a Point.

I recorded this flame graph while scrolling. Notice that `TextBufferWrapper::get_extent` makes up a large portion of the time, due to the call to `PointWrapper::from_point`.

![flame-graph](https://user-images.githubusercontent.com/326587/27756058-2be6841a-5da9-11e7-9e11-aca97a88849e.png)
