### PR TITLE
Add TextBuffer.baseTextMatchesFile method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superstring",
-  "version": "2.0.8",
+  "version": "2.0.9-0",
   "description": "A data structure to efficiently represent the results of applying patches.",
   "main": "./index",
   "browser": "./browser",

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -28,9 +28,8 @@ private:
   static void find_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_all_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void is_modified(const Nan::FunctionCallbackInfo<v8::Value> &info);
-  static void load_(const Nan::FunctionCallbackInfo<v8::Value> &info, bool force);
   static void load(const Nan::FunctionCallbackInfo<v8::Value> &info);
-  static void reload(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void base_text_matches_file(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void save(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void load_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void save_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -395,6 +395,46 @@ describe('TextBuffer', () => {
     })
   })
 
+  describe('.baseTextMatchesFile', () => {
+    if (!TextBuffer.prototype.baseTextMatchesFile) return;
+
+    it('indicates whether the base text matches the contents of the given file path', () => {
+      const content = 'abc'
+
+      const buffer = new TextBuffer(content)
+
+      const {path: filePath} = temp.openSync()
+      fs.writeFileSync(filePath, content)
+
+      return buffer.baseTextMatchesFile(filePath).then((result) => {
+        assert.ok(result)
+      }).then(() => {
+        fs.writeFileSync(filePath, content + '!')
+        return buffer.baseTextMatchesFile(filePath)
+      }).then((result) => {
+        assert.notOk(result)
+      })
+    })
+
+    it('indicates whether the base text matches the contents of the given stream', () => {
+      const content = 'abc'
+
+      const buffer = new TextBuffer(content)
+
+      const {path: filePath} = temp.openSync()
+      fs.writeFileSync(filePath, content)
+
+      return buffer.baseTextMatchesFile(fs.createReadStream(filePath)).then((result) => {
+        assert.ok(result)
+      }).then(() => {
+        fs.writeFileSync(filePath, content + '!')
+        return buffer.baseTextMatchesFile(fs.createReadStream(filePath))
+      }).then((result) => {
+        assert.notOk(result)
+      })
+    })
+  })
+
   describe('.loadSync', () => {
     if (!TextBuffer.prototype.loadSync) return;
 


### PR DESCRIPTION
Refs https://github.com/atom/text-buffer/issues/240

This adds an async API, `TextBuffer.baseTextMatchesFile`, which lets you check if a file has changed since the last time a buffer was loaded from or saved to that file.

🍐 'd on this with @nathansobo after several drinks 🍸 