### PR TITLE
Fix two issues when saving buffers to JS streams

### DIFF
--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -144,7 +144,11 @@ struct TextBuffer::Layer {
     Point goal_position = clip_position(end, splay).position;
     Point current_position = clip_position(start, splay).position;
 
-    if (!uses_patch) return callback(TextSlice(*text).slice({current_position, goal_position}));
+    if (!uses_patch) {
+      TextSlice slice = TextSlice(*text).slice({current_position, goal_position});
+      return !slice.empty() && callback(slice);
+    }
+
     if (snapshot_count > 0) splay = false;
 
     Point base_position;
@@ -158,7 +162,7 @@ struct TextBuffer::Layer {
         current_position.traversal(change->new_start),
         goal_position.traversal(change->new_start)
       });
-      if (callback(slice)) return true;
+      if (!slice.empty() && callback(slice)) return true;
       base_position = change->old_end;
       current_position = change->new_end;
     } else {
@@ -177,7 +181,7 @@ struct TextBuffer::Layer {
 
       TextSlice slice = TextSlice(*change.new_text)
         .prefix(Point::min(change.new_end, goal_position).traversal(change.new_start));
-      if (callback(slice)) return true;
+      if (!slice.empty() && callback(slice)) return true;
 
       base_position = change.old_end;
       current_position = change.new_end;

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -15,6 +15,8 @@ using MatchResult = Regex::MatchResult;
 
 uint32_t TextBuffer::MAX_CHUNK_SIZE_TO_COPY = 1024;
 
+static Text EMPTY_TEXT;
+
 struct TextBuffer::Layer {
   Layer *previous_layer;
   Patch patch;
@@ -153,7 +155,7 @@ struct TextBuffer::Layer {
       base_position = current_position;
     } else if (current_position < change->new_end) {
       TextSlice slice = TextSlice(*change->new_text).slice({
-        Point::min(change->new_end, current_position).traversal(change->new_start),
+        current_position.traversal(change->new_start),
         goal_position.traversal(change->new_start)
       });
       if (callback(slice)) return true;
@@ -227,6 +229,7 @@ struct TextBuffer::Layer {
       result.push_back(slice);
       return false;
     });
+    if (result.empty()) result.push_back(TextSlice(EMPTY_TEXT));
     return result;
   }
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -574,9 +574,21 @@ describe('TextBuffer', () => {
 
       const {path: filePath} = temp.openSync()
       const stream = fs.createWriteStream(filePath)
-      const savePromise = buffer.save(stream)
 
-      return savePromise.then(() => {
+      return buffer.save(stream).then(() => {
+        assert.equal(fs.readFileSync(filePath, 'utf8'), buffer.getText())
+      })
+    })
+
+    it('can save to a stream when the buffer has deletions (regression)', () => {
+      const buffer = new TextBuffer('abc')
+      buffer.setTextInRange(Range(Point(0, 1), Point(0, 2)), '')
+      assert.equal(buffer.getText(), 'ac')
+
+      const {path: filePath} = temp.openSync()
+      const stream = fs.createWriteStream(filePath)
+
+      return buffer.save(stream).then(() => {
         assert.equal(fs.readFileSync(filePath, 'utf8'), buffer.getText())
       })
     })

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -568,6 +568,19 @@ describe('TextBuffer', () => {
       ))
     })
 
+    it('can save to a stream when the buffer has been cleared (regression)', () => {
+      const buffer = new TextBuffer('abc')
+      buffer.setText('')
+
+      const {path: filePath} = temp.openSync()
+      const stream = fs.createWriteStream(filePath)
+      const savePromise = buffer.save(stream)
+
+      return savePromise.then(() => {
+        assert.equal(fs.readFileSync(filePath, 'utf8'), buffer.getText())
+      })
+    })
+
     describe('error handling', () => {
       it('rejects with an error if the path points to a directory', (done) => {
         const buffer = new TextBuffer('hello')

--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -98,16 +98,29 @@ TEST_CASE("TextBuffer::create_snapshot") {
 
 TEST_CASE("TextBuffer::chunks()") {
   TextBuffer buffer{u"abc"};
-  buffer.set_text_in_range({{0, 2}, {0, 3}}, u"C");
+  buffer.set_text_in_range({{0, 2}, {0, 2}}, u"1");
 
   {
     vector<u16string> chunk_strings;
     for (auto &slice : buffer.chunks()) chunk_strings.push_back(u16string(slice.data(), slice.size()));
-    REQUIRE(chunk_strings == vector<u16string>({u"ab", u"C"}));
+    REQUIRE(chunk_strings == vector<u16string>({u"ab", u"1", u"c"}));
+  }
+
+  buffer.set_text_in_range({{0, 2}, {0, 3}}, u"");
+  {
+    vector<u16string> chunk_strings;
+    for (auto &slice : buffer.chunks()) chunk_strings.push_back(u16string(slice.data(), slice.size()));
+    REQUIRE(chunk_strings == vector<u16string>({u"abc"}));
+  }
+
+  buffer.set_text_in_range({{0, 1}, {0, 2}}, u"");
+  {
+    vector<u16string> chunk_strings;
+    for (auto &slice : buffer.chunks()) chunk_strings.push_back(u16string(slice.data(), slice.size()));
+    REQUIRE(chunk_strings == vector<u16string>({u"a", u"c"}));
   }
 
   buffer.set_text(u"");
-
   {
     vector<u16string> chunk_strings;
     for (auto &slice : buffer.chunks()) chunk_strings.push_back(u16string(slice.data(), slice.size()));

--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -96,6 +96,25 @@ TEST_CASE("TextBuffer::create_snapshot") {
   }
 }
 
+TEST_CASE("TextBuffer::chunks()") {
+  TextBuffer buffer{u"abc"};
+  buffer.set_text_in_range({{0, 2}, {0, 3}}, u"C");
+
+  {
+    vector<u16string> chunk_strings;
+    for (auto &slice : buffer.chunks()) chunk_strings.push_back(u16string(slice.data(), slice.size()));
+    REQUIRE(chunk_strings == vector<u16string>({u"ab", u"C"}));
+  }
+
+  buffer.set_text(u"");
+
+  {
+    vector<u16string> chunk_strings;
+    for (auto &slice : buffer.chunks()) chunk_strings.push_back(u16string(slice.data(), slice.size()));
+    REQUIRE(chunk_strings == vector<u16string>({u""}));
+  }
+}
+
 TEST_CASE("TextBuffer::get_inverted_changes") {
   TextBuffer buffer{u"ab\ndef"};
   auto snapshot1 = buffer.create_snapshot();


### PR DESCRIPTION
This PR fixes two bugs that occurred when saving a buffer to a JS stream:

1. When all of the buffer's text had been deleted, a crash would occur because `TextBuffer::Snapshot::chunks` would return an empty vector. The returned vector now always includes at least one empty `TextSlice`.

2. When the buffer contained a deletion, `save` would only write the prefix of the buffer prior to the deletion, because the vector returned from `TextBuffer::Snapshot::chunks` would contain an empty slice. We now suppress these empty slices so that code that uses `for_each_chunk_in_range` can assume that no empty slices will be yielded unless the entire buffer (or snapshot) is empty. 

Thanks @hansonw for the detailed reports and investigation!