### PR TITLE
Add the ability to save buffers to file descriptor integers

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   }
 
   const {TextBuffer, TextWriter, TextReader} = binding
-  const {load, save, find, findAllSync, baseTextMatchesFile} = TextBuffer.prototype
+  const {load, save, saveToFileDescriptor, find, findAllSync, baseTextMatchesFile} = TextBuffer.prototype
 
   TextBuffer.prototype.load = function (source, options, progressCallback) {
     if (typeof options !== 'object') {
@@ -99,6 +99,11 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
       if (typeof destination === 'string') {
         const filePath = destination
         save.call(this, filePath, encoding, (error) => {
+          error ? reject(error) : resolve()
+        })
+      } else if (typeof destination === 'number') {
+        const fileDescriptor = destination
+        saveToFileDescriptor.call(this, fileDescriptor, encoding, (error) => {
           error ? reject(error) : resolve()
         })
       } else {

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <iomanip>
 #include <stdio.h>
+#include <stdlib.h>
 #include "point-wrapper.h"
 #include "range-wrapper.h"
 #include "string-conversion.h"
@@ -21,6 +22,10 @@ using std::vector;
 using std::wstring;
 
 #ifdef WIN32
+
+#include <io.h>
+
+#define dup _dup
 
 static wstring ToUTF16(string input) {
   wstring result;
@@ -46,6 +51,8 @@ static FILE *open_file(const string &name, const char *flags) {
 }
 
 #else
+
+#include <unistd.h>
 
 static size_t get_file_size(const std::string &name) {
   struct stat file_stats;
@@ -728,7 +735,7 @@ class SaveWorker : public Nan::AsyncWorker {
     }
 
     FILE *file = file_descriptor
-      ? fdopen(*file_descriptor, "wb+")
+      ? fdopen(dup(*file_descriptor), "wb+")
       : open_file(file_name, "wb+");
 
     if (!file) {

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -31,6 +31,7 @@ private:
   static void load(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void base_text_matches_file(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void save(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void save_to_file_descriptor(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void load_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void save_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void serialize_changes(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -484,6 +484,26 @@ describe('TextBuffer', () => {
       })
     })
 
+    it('can write the buffer\'s contents to a file descriptor', () => {
+      const buffer = new TextBuffer('abcdefghijklmnopqrstuvwxyz')
+
+      // Perform some edits just to exercise the saving logic
+      buffer.setTextInRange(Range(Point(0, 3), Point(0, 3)), '123')
+      buffer.setTextInRange(Range(Point(0, 7), Point(0, 7)), '456')
+      assert.equal(buffer.getText(), 'abc123d456efghijklmnopqrstuvwxyz')
+
+      const {path: filePath, fd} = temp.openSync()
+      const savePromise = buffer.save(fd)
+
+      buffer.setTextInRange(Range(Point(0, 11), Point(0, 11)), '789')
+      assert.equal(buffer.getText(), 'abc123d456e789fghijklmnopqrstuvwxyz')
+
+      return savePromise.then(() => {
+        assert.equal(fs.readFileSync(filePath, 'utf8'), 'abc123d456efghijklmnopqrstuvwxyz')
+        assert.equal(buffer.getText(), 'abc123d456e789fghijklmnopqrstuvwxyz')
+      })
+    })
+
     it('can write the buffer\'s content to a given stream', () => {
       const buffer = new TextBuffer('abcdefghijklmnopqrstuvwxyz')
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -501,6 +501,12 @@ describe('TextBuffer', () => {
       return savePromise.then(() => {
         assert.equal(fs.readFileSync(filePath, 'utf8'), 'abc123d456efghijklmnopqrstuvwxyz')
         assert.equal(buffer.getText(), 'abc123d456e789fghijklmnopqrstuvwxyz')
+        fs.write(fd, ' - and we can still write to the file descriptor', () => {
+          assert.equal(
+            fs.readFileSync(filePath, 'utf8'),
+            'abc123d456efghijklmnopqrstuvwxyz - and we can still write to the file descriptor'
+          )
+        })
       })
     })
 


### PR DESCRIPTION
This adds type detection on the argument to `TextBuffer.prototype.save`. If called with an integer, we assume it's a file descriptor. We aim to combine this ability with https://github.com/atom/node-runas/pull/33 to address https://github.com/atom/atom/issues/15267.

I still want to verify that we can write to the given file descriptor in the test after saving, since we close the file handle when the `SaveWorker` terminates and I'm not clear how that relates to the file descriptor.

/cc @maxbrunsfeld 