### PR TITLE
Avoid changing buffers' modified status when saves fail

### DIFF
--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -742,11 +742,12 @@ class SaveWorker : public Nan::AsyncWorker {
   }
 
   Local<Value> Finish() {
-    snapshot->flush_preceding_changes();
-    delete snapshot;
     if (error_number) {
+      delete snapshot;
       return error_for_number(*error_number, encoding_name, file_name);
     } else {
+      snapshot->flush_preceding_changes();
+      delete snapshot;
       return Nan::Null();
     }
   }

--- a/src/bindings/text-reader.h
+++ b/src/bindings/text-reader.h
@@ -18,6 +18,7 @@ private:
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void read(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void end(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void destroy(const Nan::FunctionCallbackInfo<v8::Value> &info);
 
   v8::Persistent<v8::Object> js_text_buffer;
   TextBuffer::Snapshot *snapshot;


### PR DESCRIPTION
This fixes a bug where buffers' modified status was changed to false when a save failed.