### PR TITLE
Explicitly use 64-bit stat structure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ platform:
 install:
   - ps: Install-Product node $env:nodejs_version
   - git submodule update --init
+  - node --version
+  - npm --version
   - npm install
 
 test_script:
-  - node --version
-  - npm --version
   - npm run standard
   - npm run test:node
 

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -33,8 +33,8 @@ static wstring ToUTF16(string input) {
 }
 
 static size_t get_file_size(const string &name) {
-  struct _stat file_stats;
-  if (_wstat(ToUTF16(name).c_str(), &file_stats) != 0) return -1;
+  struct _stat64 file_stats;
+  if (_wstat64(ToUTF16(name).c_str(), &file_stats) != 0) return -1;
   return file_stats.st_size;
 }
 


### PR DESCRIPTION
Even though we don't support files larger 4GB, some file systems' inode numbers are larger than 2^32, and the `stat` struct includes the inode number.

Refs https://github.com/atom/atom/issues/15236