### PR TITLE
fix intermittent `findWordsWithSubsequence` crashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,9 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   }
 
   TextBuffer.prototype.findWordsWithSubsequence = function (query, extraWordCharacters, maxCount) {
-    return new Promise(resolve => findWordsWithSubsequence.call(this, query, extraWordCharacters, maxCount, resolve))
+    return new Promise(resolve =>
+      findWordsWithSubsequence.call(this, query, extraWordCharacters, maxCount, result => resolve(result))
+    )
   }
 
   TextBuffer.prototype.baseTextMatchesFile = function (source, encoding = 'UTF8') {

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -985,6 +985,18 @@ describe('TextBuffer', () => {
   })
 
   describe('.findWordsWithSubsequence', () => {
+    it('doesn\'t crash intermittently', () => {
+      let buffer;
+      let promises = []
+      for (let k = 0; k < 100; k++) {
+        buffer = new TextBuffer('abc')
+        promises.push(
+          buffer.findWordsWithSubsequence('a', '', 10)
+        )
+      }
+      return Promise.all(promises)
+    })
+
     it('resolves with all words matching the given query', () => {
       const buffer = new TextBuffer('banana bandana ban_ana bandaid band bNa\nbanana')
       return buffer.findWordsWithSubsequence('bna', '_', 4).then((result) => {


### PR DESCRIPTION
I whittled down the `find` method and `find_words_with_subsequence` method
until they were practically the same, and `find_words_with_subsequence` was
still crashing while `find` was not. Then, I started looking at their
use and `index.js`, and the only thing I could see that was definitely
different was that `findWordsWithSubsequence` was passing the promise's
`resolve` function as the callback to the `findWordsWithSubsequence`
binding. I changed it to pass an arrow function that calls `resolve`, and the test
passed.

I would really love to know why this fix works if anyone has any
insight.