### PR TITLE
Add findWordsWithSubsequenceInRange method

### DIFF
--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -1,0 +1,56 @@
+const http = require('http')
+const fs = require('fs')
+const unzip = require('unzip')
+const { TextBuffer } = require('..')
+
+const unzipper = unzip.Parse()
+
+const getText = () => {
+  return new Promise(resolve => {
+    console.log('fetching text file...')
+    const req = http.get({
+      hostname: 'www.acleddata.com',
+      port: 80,
+      // 51 MB text file
+      path: '/wp-content/uploads/2017/01/ACLED-Version-7-All-Africa-1997-2016_csv_dyadic-file.zip',
+      agent: false
+    }, res => {
+      res
+        .pipe(unzipper)
+        .on('entry', entry => {
+          let data = '';
+          entry.on('data', chunk => data += chunk);
+          entry.on('end', () => {
+            resolve(data)
+          });
+        })
+    })
+
+    req.end()
+  })
+}
+
+const timer = size => `Time to find "cat" in ${size} file`
+
+getText().then(txt => {
+  const buffer = new TextBuffer()
+
+  console.log('running findWordsWithSubsequence tests...')
+
+  const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000]]
+
+  const test = size => {
+    const _timer = timer(size[0])
+    buffer.setText(txt.slice(0, size[1]))
+    console.time(_timer)
+    return buffer.findWordsWithSubsequence('cat', '', 100).then(sugs => {
+      console.timeEnd(_timer)
+    })
+  }
+
+  return sizes.reduce((promise, size) => {
+    return promise.then(() => test(size))
+  }, Promise.resolve())
+}).then(() => {
+  console.log('finished')
+})

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   binding = require('./browser');
 
   const {TextBuffer, Patch} = binding
-  const {find, findSync, findAllSync, findWordsWithSubsequence} = TextBuffer.prototype
+  const {find, findSync, findAllSync, findWordsWithSubsequenceInRange} = TextBuffer.prototype
 
   TextBuffer.prototype.findSync = function (pattern) {
     if (pattern.source) pattern = pattern.source
@@ -31,8 +31,15 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   }
 
   TextBuffer.prototype.findWordsWithSubsequence = function (query, extraWordCharacters, maxCount) {
+    const range = {start: {row: 0, column: 0}, end: this.getExtent()}
     return Promise.resolve(
-      findWordsWithSubsequence.call(this, query, extraWordCharacters).slice(0, maxCount)
+      findWordsWithSubsequenceInRange.call(this, query, extraWordCharacters, range).slice(0, maxCount)
+    )
+  }
+
+  TextBuffer.prototype.findWordsWithSubsequenceInRange = function (query, extraWordCharacters, maxCount, range) {
+    return Promise.resolve(
+      findWordsWithSubsequenceInRange.call(this, query, extraWordCharacters, range).slice(0, maxCount)
     )
   }
 
@@ -62,7 +69,7 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   }
 
   const {TextBuffer, TextWriter, TextReader} = binding
-  const {load, save, find, findAllSync, findWordsWithSubsequence, baseTextMatchesFile} = TextBuffer.prototype
+  const {load, save, find, findAllSync, findWordsWithSubsequenceInRange, baseTextMatchesFile} = TextBuffer.prototype
 
   TextBuffer.prototype.load = function (source, options, progressCallback) {
     if (typeof options !== 'object') {
@@ -173,8 +180,15 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   }
 
   TextBuffer.prototype.findWordsWithSubsequence = function (query, extraWordCharacters, maxCount) {
+    const range = {start: {row: 0, column: 0}, end: this.getExtent()}
     return new Promise(resolve =>
-      findWordsWithSubsequence.call(this, query, extraWordCharacters, maxCount, resolve)
+      findWordsWithSubsequenceInRange.call(this, query, extraWordCharacters, maxCount, range, resolve)
+    )
+  }
+
+  TextBuffer.prototype.findWordsWithSubsequenceInRange = function (query, extraWordCharacters, maxCount, range) {
+    return new Promise(resolve =>
+      findWordsWithSubsequenceInRange.call(this, query, extraWordCharacters, maxCount, range, resolve)
     )
   }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "random-seed": "^0.2.0",
     "stackvis": "^0.4.0",
     "standard": "^4.5.4",
-    "temp": "^0.8.3"
+    "temp": "^0.8.3",
+    "unzip": "^0.1.11"
   },
   "standard": {
     "global": [

--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -82,7 +82,7 @@ EMSCRIPTEN_BINDINGS(TextBuffer) {
     .function("isModified", WRAP_OVERLOAD(&TextBuffer::is_modified, bool (TextBuffer::*)() const))
     .function("findSync", find_sync)
     .function("findAllSync", find_all_sync)
-    .function("findWordsWithSubsequence", WRAP(&TextBuffer::find_words_with_subsequence));
+    .function("findWordsWithSubsequenceInRange", WRAP(&TextBuffer::find_words_with_subsequence_in_range));
 
   emscripten::value_object<TextBuffer::SubsequenceMatch>("SubsequenceMatch")
     .field("word", WRAP_FIELD(TextBuffer::SubsequenceMatch, word))

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -27,7 +27,7 @@ private:
   static void find(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_all_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
-  static void find_words_with_subsequence(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void find_words_with_subsequence_in_range(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void is_modified(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void load(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void base_text_matches_file(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -389,7 +389,7 @@ struct TextBuffer::Layer {
     int16_t score = 0;
   };
 
-  vector<SubsequenceMatch> find_words_with_subsequence(u16string query, const u16string &extra_word_characters) {
+  vector<SubsequenceMatch> find_words_with_subsequence_in_range(u16string query, const u16string &extra_word_characters, Range range) {
     size_t query_index = 0;
     Point position;
     Point current_word_start;
@@ -401,7 +401,7 @@ struct TextBuffer::Layer {
     // subsequence.
     std::unordered_map<u16string, vector<Point>> substring_matches;
 
-    for_each_chunk_in_range(Point(), extent(), [&] (TextSlice chunk) -> bool {
+    for_each_chunk_in_range(range.start, range.end, [&] (TextSlice chunk) -> bool {
       for (uint16_t c : chunk) {
         bool is_word_character =
           std::iswalnum(c) ||
@@ -809,8 +809,8 @@ bool TextBuffer::SubsequenceMatch::operator==(const SubsequenceMatch &other) con
   );
 }
 
-vector<SubsequenceMatch> TextBuffer::find_words_with_subsequence(const u16string &query, const u16string &non_word_characters) const {
-  return top_layer->find_words_with_subsequence(query, non_word_characters);
+vector<SubsequenceMatch> TextBuffer::find_words_with_subsequence_in_range(const u16string &query, const u16string &non_word_characters, Range range) const {
+  return top_layer->find_words_with_subsequence_in_range(query, non_word_characters, range);
 }
 
 bool TextBuffer::is_modified() const {
@@ -901,8 +901,8 @@ optional<Range> TextBuffer::Snapshot::find(const Regex &regex) const {
   return layer.search_in_range(regex, Range{Point(), extent()}, false);
 }
 
-vector<SubsequenceMatch> TextBuffer::Snapshot::find_words_with_subsequence(std::u16string query, const std::u16string &extra_word_characters) const {
-  return layer.find_words_with_subsequence(query, extra_word_characters);
+vector<SubsequenceMatch> TextBuffer::Snapshot::find_words_with_subsequence_in_range(std::u16string query, const std::u16string &extra_word_characters, Range range) const {
+  return layer.find_words_with_subsequence_in_range(query, extra_word_characters, range);
 }
 
 const Text &TextBuffer::Snapshot::base_text() const {

--- a/src/core/text-buffer.h
+++ b/src/core/text-buffer.h
@@ -59,7 +59,7 @@ public:
     bool operator==(const SubsequenceMatch &) const;
   };
 
-  std::vector<SubsequenceMatch> find_words_with_subsequence(const std::u16string &, const std::u16string &) const;
+  std::vector<SubsequenceMatch> find_words_with_subsequence_in_range(const std::u16string &, const std::u16string &, Range) const;
 
   class Snapshot {
     friend class TextBuffer;
@@ -82,7 +82,7 @@ public:
     std::u16string text_in_range(Range) const;
     const Text &base_text() const;
     optional<Range> find(const Regex &) const;
-    std::vector<SubsequenceMatch> find_words_with_subsequence(std::u16string query, const std::u16string &extra_word_characters) const;
+    std::vector<SubsequenceMatch> find_words_with_subsequence_in_range(std::u16string query, const std::u16string &extra_word_characters, Range range) const;
   };
 
   friend class Snapshot;

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -984,7 +984,7 @@ describe('TextBuffer', () => {
     })
   })
 
-  describe('.findWordsWithSubsequence', () => {
+  describe('.findWordsWithSubsequence and .findWordsWithSubsequenceInRange', () => {
     it('doesn\'t crash intermittently', () => {
       let buffer;
       let promises = []
@@ -1017,6 +1017,33 @@ describe('TextBuffer', () => {
             score: 12,
             matchIndices: [0, 2, 3],
             positions: [{row: 0, column: 0}, {row: 1, column: 0}],
+            word: "banana"
+          },
+          {
+            score: 7,
+            matchIndices: [0, 5, 6],
+            positions: [{row: 0, column: 7}],
+            word: "bandana"
+          }
+        ])
+      })
+    })
+
+    it('resolves with all words matching the given query and range', () => {
+      const buffer = new TextBuffer('banana bandana ban_ana bandaid band bNa\nbanana')
+      const range = {start: {column: 0, row: 0}, end: {column: 22, row: 0}}
+      return buffer.findWordsWithSubsequenceInRange('bna', '_', 4, range).then((result) => {
+        assert.deepEqual(result, [
+          {
+            score: 16,
+            matchIndices: [0, 2, 4],
+            positions: [{row: 0, column: 15}],
+            word: "ban_ana"
+          },
+          {
+            score: 12,
+            matchIndices: [0, 2, 3],
+            positions: [{row: 0, column: 0}],
             word: "banana"
           },
           {

--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -404,11 +404,11 @@ TEST_CASE("TextBuffer::find_all") {
   }));
 }
 
-TEST_CASE("TextBuffer::find_words_with_subsequence") {
+TEST_CASE("TextBuffer::find_words_with_subsequence_in_range") {
   {
     TextBuffer buffer{u"banana band bandana banana"};
 
-    REQUIRE(buffer.find_words_with_subsequence(u"bna", u"") == vector<SubsequenceMatch>({
+    REQUIRE(buffer.find_words_with_subsequence_in_range(u"bna", u"", Range{Point{0, 0}, Point{0, UINT32_MAX}}) == vector<SubsequenceMatch>({
       {u"banana", {Point{0, 0}, Point{0, 20}}, {0, 2, 3}, 12},
       {u"bandana", {Point{0, 12}}, {0, 5, 6}, 7}
     }));
@@ -417,7 +417,7 @@ TEST_CASE("TextBuffer::find_words_with_subsequence") {
   {
     TextBuffer buffer{u"a_b_c abc aBc"};
 
-    REQUIRE(buffer.find_words_with_subsequence(u"abc", u"_") == vector<SubsequenceMatch>({
+    REQUIRE(buffer.find_words_with_subsequence_in_range(u"abc", u"_", Range{Point{0, 0}, Point{0, UINT32_MAX}}) == vector<SubsequenceMatch>({
       {u"aBc", {Point{0, 10}}, {0, 1, 2}, 30},
       {u"a_b_c", {Point{0, 0}}, {0, 2, 4}, 26},
       {u"abc", {Point{0, 6}}, {0, 1, 2}, 20},


### PR DESCRIPTION
In very large buffers, we'll need to put a limit on the range in which we search for subsequence matches to stay performant. This method lets us do that.

I've left `.findWordsWithSubsequence` intact. It just calls `.findWordsWithSubsequenceInRange` with the full range. The only native function is `find_words_with_subsequence_in_range`.

I'm also including a simple benchmark for a very large file:
```
~/github/superstring/benchmark (ns-mb-substring-match-in-range)$ node large-text-buffer.benchmark.js 
fetching text file...
running findWordsWithSubsequence tests...
Time to find "cat" in 10b file: 4.999ms
Time to find "cat" in 100b file: 3.968ms
Time to find "cat" in 1kb file: 1.402ms
Time to find "cat" in 1MB file: 19.547ms
Time to find "cat" in 51MB file: 849.399ms
finished
```
I  don't have a good explanation for why the 100b and 1kb result are lower than the 10b result. Caching perhaps?