### PR TITLE
Flesh out the regex search APIs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 image: Visual Studio 2015
 
 environment:
-  nodejs_version: "6"
+  nodejs_version: "8"
 
 platform:
   - x86

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,8 @@ dependencies:
   pre:
     - git submodule update --init
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.3/install.sh | bash
-    - nvm install 6.9.4
-    - nvm use 6.9.4
+    - nvm install 8.4
+    - nvm use 8.4
 
   override:
     - npm install

--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -9,7 +9,7 @@ static TextBuffer *construct(const std::string &text) {
   return new TextBuffer(u16string(text.begin(), text.end()));
 }
 
-static emscripten::val find_sync(TextBuffer &buffer, std::string js_pattern) {
+static emscripten::val find_sync(TextBuffer &buffer, std::string js_pattern, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
   Regex regex(pattern, &error_message);
@@ -17,7 +17,7 @@ static emscripten::val find_sync(TextBuffer &buffer, std::string js_pattern) {
     return emscripten::val(string(error_message.begin(), error_message.end()));
   }
 
-  auto result = buffer.find(regex);
+  auto result = buffer.find(regex, range);
   if (result) {
     return emscripten::val(*result);
   }
@@ -25,7 +25,7 @@ static emscripten::val find_sync(TextBuffer &buffer, std::string js_pattern) {
   return emscripten::val::null();
 }
 
-static emscripten::val find_all_sync(TextBuffer &buffer, std::string js_pattern) {
+static emscripten::val find_all_sync(TextBuffer &buffer, std::string js_pattern, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
   Regex regex(pattern, &error_message);
@@ -33,7 +33,7 @@ static emscripten::val find_all_sync(TextBuffer &buffer, std::string js_pattern)
     return emscripten::val(string(error_message.begin(), error_message.end()));
   }
 
-  return em_transmit(buffer.find_all(regex));
+  return em_transmit(buffer.find_all(regex, range));
 }
 
 static emscripten::val line_ending_for_row(TextBuffer &buffer, uint32_t row) {

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -223,6 +223,7 @@ void TextBufferWrapper::init(Local<Object> exports) {
   prototype_template->Set(Nan::New("baseTextDigest").ToLocalChecked(), Nan::New<FunctionTemplate>(base_text_digest));
   prototype_template->Set(Nan::New("find").ToLocalChecked(), Nan::New<FunctionTemplate>(find));
   prototype_template->Set(Nan::New("findSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_sync));
+  prototype_template->Set(Nan::New("findAll").ToLocalChecked(), Nan::New<FunctionTemplate>(find_all));
   prototype_template->Set(Nan::New("findAllSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_all_sync));
   prototype_template->Set(Nan::New("findWordsWithSubsequenceInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(find_words_with_subsequence_in_range));
   prototype_template->Set(Nan::New("getDotGraph").ToLocalChecked(), Nan::New<FunctionTemplate>(dot_graph));
@@ -362,16 +363,58 @@ void TextBufferWrapper::position_for_character_index(const Nan::FunctionCallback
   }
 }
 
+template <bool single_result>
+class TextBufferSearcher : public Nan::AsyncWorker {
+  const TextBuffer::Snapshot *snapshot;
+  const Regex *regex;
+  vector<Range> matches;
+  Nan::Persistent<Value> argument;
+
+public:
+  TextBufferSearcher(Nan::Callback *completion_callback,
+                     const TextBuffer::Snapshot *snapshot,
+                     const Regex *regex,
+                     Local<Value> arg) :
+    AsyncWorker(completion_callback),
+    snapshot{snapshot},
+    regex{regex} {
+    argument.Reset(arg);
+  }
+
+  void Execute() {
+    if (single_result) {
+      auto find_result = snapshot->find(*regex);
+      if (find_result) {
+        matches.push_back(*find_result);
+      }
+    } else {
+      matches = snapshot->find_all(*regex);
+    }
+  }
+
+  Local<Value> Finish() {
+    delete snapshot;
+    auto length = matches.size() * 4;
+    auto buffer = v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), length * sizeof(uint32_t));
+    auto result = v8::Uint32Array::New(buffer, 0, length);
+    auto data = buffer->GetContents().Data();
+    memcpy(data, matches.data(), length * sizeof(uint32_t));
+    return result;
+  }
+
+  void HandleOKCallback() {
+    Local<Value> argv[] = {Nan::Null(), Finish()};
+    callback->Call(2, argv);
+  }
+};
+
 void TextBufferWrapper::find_sync(const Nan::FunctionCallbackInfo<Value> &info) {
   auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
   const Regex *regex = RegexWrapper::regex_from_js(info[0]);
   if (regex) {
-    auto result = text_buffer.find(*regex);
-    if (result) {
-      info.GetReturnValue().Set(RangeWrapper::from_range(*result));
-    } else {
-      info.GetReturnValue().Set(Nan::Null());
-    }
+    TextBufferSearcher<true> searcher(nullptr, text_buffer.create_snapshot(), regex, info[0]);
+    searcher.Execute();
+    info.GetReturnValue().Set(searcher.Finish());
   }
 }
 
@@ -379,55 +422,32 @@ void TextBufferWrapper::find_all_sync(const Nan::FunctionCallbackInfo<Value> &in
   auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
   const Regex *regex = RegexWrapper::regex_from_js(info[0]);
   if (regex) {
-    auto matches = text_buffer.find_all(*regex);
-    auto length = matches.size() * 4;
-    auto buffer = v8::ArrayBuffer::New(v8::Isolate::GetCurrent(), length * sizeof(uint32_t));
-    auto result = v8::Uint32Array::New(buffer, 0, length);
-    auto data = buffer->GetContents().Data();
-    memcpy(data, matches.data(), length * sizeof(uint32_t));
-    info.GetReturnValue().Set(result);
+    TextBufferSearcher<false> searcher(nullptr, text_buffer.create_snapshot(), regex, info[0]);
+    searcher.Execute();
+    info.GetReturnValue().Set(searcher.Finish());
   }
 }
 
 void TextBufferWrapper::find(const Nan::FunctionCallbackInfo<Value> &info) {
-  class TextBufferSearcher : public Nan::AsyncWorker {
-    const TextBuffer::Snapshot *snapshot;
-    const Regex *regex;
-    optional<Range> result;
-    Nan::Persistent<Value> argument;
-
-  public:
-    TextBufferSearcher(Nan::Callback *completion_callback,
-                       const TextBuffer::Snapshot *snapshot,
-                       const Regex *regex,
-                       Local<Value> arg) :
-      AsyncWorker(completion_callback),
-      snapshot{snapshot},
-      regex{regex} {
-      argument.Reset(arg);
-    }
-
-    void Execute() {
-      result = snapshot->find(*regex);
-    }
-
-    void HandleOKCallback() {
-      delete snapshot;
-      if (result) {
-        Local<Value> argv[] = {Nan::Null(), RangeWrapper::from_range(*result)};
-        callback->Call(2, argv);
-      } else {
-        Local<Value> argv[] = {Nan::Null(), Nan::Null()};
-        callback->Call(2, argv);
-      }
-    }
-  };
-
   auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
   auto callback = new Nan::Callback(info[1].As<Function>());
   const Regex *regex = RegexWrapper::regex_from_js(info[0]);
   if (regex) {
-    Nan::AsyncQueueWorker(new TextBufferSearcher(
+    Nan::AsyncQueueWorker(new TextBufferSearcher<true>(
+      callback,
+      text_buffer.create_snapshot(),
+      regex,
+      info[0]
+    ));
+  }
+}
+
+void TextBufferWrapper::find_all(const Nan::FunctionCallbackInfo<Value> &info) {
+  auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
+  auto callback = new Nan::Callback(info[1].As<Function>());
+  const Regex *regex = RegexWrapper::regex_from_js(info[0]);
+  if (regex) {
+    Nan::AsyncQueueWorker(new TextBufferSearcher<false>(
       callback,
       text_buffer.create_snapshot(),
       regex,

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -26,6 +26,7 @@ private:
   static void position_for_character_index(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void find_all(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_all_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_words_with_subsequence_in_range(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void is_modified(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/src/core/point.cc
+++ b/src/core/point.cc
@@ -10,6 +10,10 @@ Point Point::max(const Point &left, const Point &right) {
   return left >= right ? left : right;
 }
 
+Point Point::max() {
+  return Point(UINT32_MAX, UINT32_MAX);
+}
+
 Point::Point() : Point(0, 0) {}
 
 Point::Point(unsigned row, unsigned column) : row{row}, column{column} {}

--- a/src/core/point.h
+++ b/src/core/point.h
@@ -10,6 +10,7 @@ struct Point {
 
   static Point min(const Point &left, const Point &right);
   static Point max(const Point &left, const Point &right);
+  static Point max();
 
   Point();
   Point(unsigned row, unsigned column);

--- a/src/core/range.cc
+++ b/src/core/range.cc
@@ -1,5 +1,9 @@
 #include "range.h"
 
+Range Range::all_inclusive() {
+  return Range{Point(), Point::max()};
+}
+
 Point Range::extent() const {
   return end.traversal(start);
 }

--- a/src/core/range.h
+++ b/src/core/range.h
@@ -8,6 +8,8 @@ struct Range {
   Point start;
   Point end;
 
+  static Range all_inclusive();
+
   Point extent() const;
 
   bool operator==(const Range &other) const {

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -901,6 +901,10 @@ optional<Range> TextBuffer::Snapshot::find(const Regex &regex) const {
   return layer.search_in_range(regex, Range{Point(), extent()}, false);
 }
 
+vector<Range> TextBuffer::Snapshot::find_all(const Regex &regex) const {
+  return layer.find_all_in_range(regex, Range{Point(), extent()}, false);
+}
+
 vector<SubsequenceMatch> TextBuffer::Snapshot::find_words_with_subsequence_in_range(std::u16string query, const std::u16string &extra_word_characters, Range range) const {
   return layer.find_words_with_subsequence_in_range(query, extra_word_characters, range);
 }

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -254,7 +254,9 @@ struct TextBuffer::Layer {
     Point last_search_end_position = range.start;
     Point slice_to_search_start_position = range.start;
 
-    for_each_chunk_in_range(range.start, range.end, [&](TextSlice chunk) {
+    Point end = clip_position(range.end).position;
+
+    for_each_chunk_in_range(range.start, end, [&](TextSlice chunk) {
       Point chunk_end_position = chunk_start_position.traverse(chunk.extent());
       while (last_search_end_position < chunk_end_position) {
         TextSlice remaining_chunk = chunk
@@ -285,7 +287,7 @@ struct TextBuffer::Layer {
           slice_to_search_start_position.traverse(slice_to_search.extent());
 
         int options = 0;
-        if (slice_to_search_end_position == range.end) options |= MatchOptions::IsEndOfFile;
+        if (slice_to_search_end_position == end) options |= MatchOptions::IsEndOfFile;
         if (slice_to_search_start_position.column == 0) options |= MatchOptions::IsBeginningOfLine;
 
         MatchResult match_result = regex.match(
@@ -365,7 +367,7 @@ struct TextBuffer::Layer {
     }
   }
 
-  optional<Range> search_in_range(const Regex &regex, Range range, bool splay = false) {
+  optional<Range> find_in_range(const Regex &regex, Range range, bool splay = false) {
     optional<Range> result;
     scan_in_range(regex, range, [&result](Range match_range) -> bool {
       result = match_range;
@@ -792,12 +794,12 @@ void TextBuffer::set_text_in_range(Range old_range, u16string &&string) {
   }
 }
 
-optional<Range> TextBuffer::find(const Regex &regex) const {
-  return top_layer->search_in_range(regex, Range{Point(), extent()}, false);
+optional<Range> TextBuffer::find(const Regex &regex, Range range) const {
+  return top_layer->find_in_range(regex, range, false);
 }
 
-vector<Range> TextBuffer::find_all(const Regex &regex) const {
-  return top_layer->find_all_in_range(regex, Range{Point(), extent()}, false);
+vector<Range> TextBuffer::find_all(const Regex &regex, Range range) const {
+  return top_layer->find_all_in_range(regex, range, false);
 }
 
 bool TextBuffer::SubsequenceMatch::operator==(const SubsequenceMatch &other) const {
@@ -897,12 +899,12 @@ vector<TextSlice> TextBuffer::Snapshot::chunks() const {
   return layer.chunks_in_range({{0, 0}, extent()});
 }
 
-optional<Range> TextBuffer::Snapshot::find(const Regex &regex) const {
-  return layer.search_in_range(regex, Range{Point(), extent()}, false);
+optional<Range> TextBuffer::Snapshot::find(const Regex &regex, Range range) const {
+  return layer.find_in_range(regex, range, false);
 }
 
-vector<Range> TextBuffer::Snapshot::find_all(const Regex &regex) const {
-  return layer.find_all_in_range(regex, Range{Point(), extent()}, false);
+vector<Range> TextBuffer::Snapshot::find_all(const Regex &regex, Range range) const {
+  return layer.find_all_in_range(regex, range, false);
 }
 
 vector<SubsequenceMatch> TextBuffer::Snapshot::find_words_with_subsequence_in_range(std::u16string query, const std::u16string &extra_word_characters, Range range) const {

--- a/src/core/text-buffer.h
+++ b/src/core/text-buffer.h
@@ -82,6 +82,7 @@ public:
     std::u16string text_in_range(Range) const;
     const Text &base_text() const;
     optional<Range> find(const Regex &) const;
+    std::vector<Range> find_all(const Regex &) const;
     std::vector<SubsequenceMatch> find_words_with_subsequence_in_range(std::u16string query, const std::u16string &extra_word_characters, Range range) const;
   };
 

--- a/src/core/text-buffer.h
+++ b/src/core/text-buffer.h
@@ -48,8 +48,8 @@ public:
   bool deserialize_changes(Deserializer &);
   const Text &base_text() const;
 
-  optional<Range> find(const Regex &) const;
-  std::vector<Range> find_all(const Regex &) const;
+  optional<Range> find(const Regex &, Range range = Range::all_inclusive()) const;
+  std::vector<Range> find_all(const Regex &, Range range = Range::all_inclusive()) const;
 
   struct SubsequenceMatch {
     std::u16string word;
@@ -81,8 +81,8 @@ public:
     std::u16string text() const;
     std::u16string text_in_range(Range) const;
     const Text &base_text() const;
-    optional<Range> find(const Regex &) const;
-    std::vector<Range> find_all(const Regex &) const;
+    optional<Range> find(const Regex &, Range range = Range::all_inclusive()) const;
+    std::vector<Range> find_all(const Regex &, Range range = Range::all_inclusive()) const;
     std::vector<SubsequenceMatch> find_words_with_subsequence_in_range(std::u16string query, const std::u16string &extra_word_characters, Range range) const;
   };
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -923,6 +923,25 @@ describe('TextBuffer', () => {
     })
   })
 
+  describe('.findInRange (sync and async)', () => {
+    it('returns the range of the first match in the given range', async () => {
+      const buffer = new TextBuffer('abc def\nghi jkl\n')
+
+      assert.deepEqual(
+        buffer.findInRangeSync(/\w+/, Range(Point(0, 1), Point(1, 2))),
+        Range(Point(0, 1), Point(0, 3)))
+      assert.deepEqual(
+        await buffer.findInRange(/\w+/, Range(Point(0, 1), Point(1, 2))),
+        Range(Point(0, 1), Point(0, 3)))
+      assert.deepEqual(
+        buffer.findInRangeSync(/j\w*/, Range(Point(0, 0), Point(1, 6))),
+        Range(Point(1, 4), Point(1, 6)))
+      assert.deepEqual(
+        await buffer.findInRange(/j\w*/, Range(Point(0, 0), Point(1, 6))),
+        Range(Point(1, 4), Point(1, 6)))
+    })
+  })
+
   describe('.findAll (sync and async)', () => {
     it('returns the ranges of all matches of the given pattern', async () => {
       const buffer = new TextBuffer('abcd')
@@ -983,6 +1002,23 @@ describe('TextBuffer', () => {
           assert.deepEqual(actualRanges, expectedRanges, `Regex: ${regex}, text: ${testDocument.getText()}`)
         }
       }
+    })
+  })
+
+  describe('.findAllInRange (sync and async)', () => {
+    it('returns the ranges of all matches of the given pattern within the given range', async () => {
+      const buffer = new TextBuffer('abc def\nghi jkl\n')
+
+      assert.deepEqual(buffer.findAllInRangeSync(/\w+/, Range(Point(0, 1), Point(1, 2))), [
+        Range(Point(0, 1), Point(0, 3)),
+        Range(Point(0, 4), Point(0, 7)),
+        Range(Point(1, 0), Point(1, 2))
+      ])
+      assert.deepEqual(await buffer.findAllInRange(/\w+/, Range(Point(0, 1), Point(1, 2))), [
+        Range(Point(0, 1), Point(0, 3)),
+        Range(Point(0, 4), Point(0, 7)),
+        Range(Point(1, 0), Point(1, 2))
+      ])
     })
   })
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -872,8 +872,8 @@ describe('TextBuffer', () => {
     })
   })
 
-  describe('.findSync', () => {
-    it('returns the range of the first match with the given pattern', () => {
+  describe('.find (sync and async)', () => {
+    it('returns the range of the first match with the given pattern', async () => {
       const buffer = new TextBuffer('abc\ndef')
       buffer.setTextInRange(Range(Point(0, 0), Point(0, 0)), '1')
       buffer.setTextInRange(Range(Point(0, 3), Point(0, 4)), '2')
@@ -882,22 +882,59 @@ describe('TextBuffer', () => {
       assert.deepEqual(buffer.findSync('b2'), Range(Point(0, 2), Point(0, 4)))
       assert.deepEqual(buffer.findSync('bc'), null)
       assert.deepEqual(buffer.findSync('^d'), Range(Point(1, 0), Point(1, 1)))
+
+      assert.deepEqual(await buffer.find('b2'), Range(Point(0, 2), Point(0, 4)))
+      assert.deepEqual(await buffer.find('bc'), null)
+      assert.deepEqual(await buffer.find('^d'), Range(Point(1, 0), Point(1, 1)))
     })
 
-    it('throws an exception if an invalid pattern is passed', () => {
+    it('throws an exception if an invalid pattern is passed', async () => {
       const buffer = new TextBuffer('abc\ndef')
-      assert.throws(() => buffer.findSync('['), /missing terminating ] for character class/)
+
+      try {
+        buffer.findSync('[')
+        assert(false, 'Expected an exceptoin')
+      } catch (error) {
+        assert.match(error.message, /missing terminating ] for character class/)
+      }
+
+      try {
+        await buffer.find('[')
+        assert(false, 'Expected an exceptoin')
+      } catch (error) {
+        assert.match(error.message, /missing terminating ] for character class/)
+      }
+    })
+
+    it('can be called repeatedly with the same RegExp to avoid recompiling the RegExp', async () => {
+      const buffer = new TextBuffer('abc\ndef')
+
+      const regex = /b/
+      assert.deepEqual(buffer.findSync(regex), Range(Point(0, 1), Point(0, 2)))
+      assert.deepEqual(await buffer.find(regex), Range(Point(0, 1), Point(0, 2)))
+
+      buffer.setTextInRange(Range(Point(0, 0), Point(0, 0)), ' ')
+      assert.deepEqual(buffer.findSync(regex), Range(Point(0, 2), Point(0, 3)))
+      assert.deepEqual(await buffer.find(regex), Range(Point(0, 2), Point(0, 3)))
+
+      buffer.setTextInRange(Range(Point(0, 0), Point(0, 0)), ' ')
+      assert.deepEqual(buffer.findSync(regex), Range(Point(0, 3), Point(0, 4)))
+      assert.deepEqual(await buffer.find(regex), Range(Point(0, 3), Point(0, 4)))
     })
   })
 
-  describe('.findAllSync', () => {
-    it('returns the ranges of all matches of the given pattern', () => {
+  describe('.findAll (sync and async)', () => {
+    it('returns the ranges of all matches of the given pattern', async () => {
       const buffer = new TextBuffer('abcd')
       buffer.setTextInRange(Range(Point(0, 1), Point(0, 1)), '1')
       buffer.setTextInRange(Range(Point(0, 3), Point(0, 3)), '2')
       assert.equal(buffer.getText(), 'a1b2cd')
 
       assert.deepEqual(buffer.findAllSync(/\d[a-z]/), [
+        Range(Point(0, 1), Point(0, 3)),
+        Range(Point(0, 3), Point(0, 5)),
+      ])
+      assert.deepEqual(await buffer.findAll(/\d[a-z]/), [
         Range(Point(0, 1), Point(0, 3)),
         Range(Point(0, 3), Point(0, 5)),
       ])
@@ -946,41 +983,6 @@ describe('TextBuffer', () => {
           assert.deepEqual(actualRanges, expectedRanges, `Regex: ${regex}, text: ${testDocument.getText()}`)
         }
       }
-    })
-  })
-
-  describe('.find', () => {
-    it('resolves with the range of the first match with the given pattern', () => {
-      const buffer = new TextBuffer('abc\ndef')
-      buffer.setTextInRange(Range(Point(0, 0), Point(0, 0)), '1')
-      buffer.setTextInRange(Range(Point(0, 3), Point(0, 4)), '2')
-      assert.equal(buffer.getText(), '1ab2\ndef')
-
-      return Promise.all([
-        buffer.find('b2').then(value => assert.deepEqual(value, Range(Point(0, 2), Point(0, 4)))),
-        buffer.find('bc').then(value => assert.deepEqual(value, null)),
-        buffer.find('^d').then(value => assert.deepEqual(value, Range(Point(1, 0), Point(1, 1))))
-      ])
-    })
-
-    it('rejects the promise if an invalid pattern is given', () => {
-      const buffer = new TextBuffer('abc\ndef')
-      return buffer.find('[')
-        .then(() => assert(false))
-        .catch((error) => assert.match(error.message, /missing terminating ] for character class/))
-    })
-
-    it('can find for a RegExp or a string', () => {
-      const buffer = new TextBuffer('abc\ndef')
-      const regex = /b/
-      return buffer.find(regex)
-        .then((result) => assert.deepEqual(result, Range(Point(0, 1), Point(0, 2))))
-        .then(() => buffer.setTextInRange(Range(Point(0, 0), Point(0, 0)), ' '))
-        .then(() => buffer.find(regex))
-        .then((result) => assert.deepEqual(result, Range(Point(0, 2), Point(0, 3))))
-        .then(() => buffer.setTextInRange(Range(Point(0, 0), Point(0, 0)), ' '))
-        .then(() => buffer.find(regex))
-        .then((result) => assert.deepEqual(result, Range(Point(0, 3), Point(0, 4))))
     })
   })
 


### PR DESCRIPTION
### Problem

While @leroix and I were looking into the performance of the new [`findWordsWithSubsequence` method](https://github.com/atom/superstring/pull/34) and [its use in autocomplete-plus](https://github.com/atom/autocomplete-plus/pull/886), we noticed that a huge amount of time was being spent in [the `Cursor.getCurrentWordBufferRange` method](https://github.com/atom/atom/blob/be2aa7b6f57286508d457ac26bb9fcb20c37cf99/src/cursor.coffee#L527). 

There are a few reasons why this method is slow:
* It uses the old `TextBuffer.scanInRange` API rather than a native search API from superstring.
* The `scanInRange` APIs are especially inefficient when they are passed RegExps that can potentially match across line breaks. Currently, RegExps that contain negated character classes (e.g. `[^x]` are assumed to be potentially multi-line.
* The word-regex used by `getCurrentWordBufferRange` uses a negated character class based on the `editor.nonWordCharacters` config setting.

### Solution

We should optimize `scanInRange`, ideally using superstring's native search functionality.

### First step

This PR expands the set of search APIs. The final list of search APIs will be as follows:

* [x] `find`
* [x] `findSync`
* [x] `findAll`
* [x] `findAllSync`
* [x] `findInRange`
* [x] `findInRangeSync`
* [x] `findAllInRange`
* [x] `findAllInRangeSync`

Before actually changing `TextBuffer.scanInRange`, I'm going to update Atom to use the native API *just* for `Cursor.getCurrentWordBufferRange`. That will fix the most immediate performance problem. Then later we can take on the more risky task of updating `scanInRange`.

/cc @nathansobo