### PR TITLE
Fix sorting ambiguity bug in findWordsWithSubsequence

### DIFF
--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -507,7 +507,10 @@ struct TextBuffer::Layer {
     }
 
     std::sort(matches.begin(), matches.end(), [] (const SubsequenceMatch &a, const SubsequenceMatch &b) {
-      return a.score > b.score;
+      // Doing it this way helps us avoid sorting ambiguity keeping the ordering the same across platforms.
+      if (a.score > b.score) return true;
+      if (b.score > a.score) return false;
+      return a.word < b.word;
     });
 
     return matches;


### PR DESCRIPTION
A test in autocomplete-plus is failing because matches that have the same score may be sorted differently across platforms. This should fix that.