### PR TITLE
Add case sensitivity to subword start bonus

### DIFF
--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -409,6 +409,7 @@ struct TextBuffer::Layer {
     Point position;
     Point current_word_start;
     u16string current_word;
+    u16string raw_query = query;
 
     std::transform(query.begin(), query.end(), query.begin(), std::towlower);
 
@@ -457,7 +458,8 @@ struct TextBuffer::Layer {
     // match against the query.
 
     static const unsigned consecutive_bonus = 5;
-    static const unsigned subword_start_bonus = 10;
+    static const unsigned subword_start_with_case_match_bonus = 10;
+    static const unsigned subword_start_with_case_mismatch_bonus = 9;
     static const unsigned mismatch_penalty = 1;
     static const unsigned leading_mismatch_penalty = 3;
 
@@ -484,7 +486,9 @@ struct TextBuffer::Layer {
               if (i == 0 ||
                   !std::iswalnum(word[i - 1]) ||
                   (std::iswlower(word[i - 1]) && std::iswupper(word[i]))) {
-                new_match.score += subword_start_bonus;
+                new_match.score += word[i] == raw_query[match_variants[j].query_index]
+                  ? subword_start_with_case_match_bonus
+                  : subword_start_with_case_mismatch_bonus;
               }
 
               if (!new_match.match_indices.empty() && new_match.match_indices.back() == i - 1) {

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1097,7 +1097,7 @@ describe('TextBuffer', () => {
       return buffer.findWordsWithSubsequence('bna', '_', 4).then((result) => {
         assert.deepEqual(result, [
           {
-            score: 30,
+            score: 29,
             matchIndices: [0, 1, 2 ],
             positions: [{row: 0, column: 36}],
             word: "bNa"

--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -418,9 +418,18 @@ TEST_CASE("TextBuffer::find_words_with_subsequence_in_range") {
     TextBuffer buffer{u"a_b_c abc aBc"};
 
     REQUIRE(buffer.find_words_with_subsequence_in_range(u"abc", u"_", Range{Point{0, 0}, Point{0, UINT32_MAX}}) == vector<SubsequenceMatch>({
-      {u"aBc", {Point{0, 10}}, {0, 1, 2}, 30},
+      {u"aBc", {Point{0, 10}}, {0, 1, 2}, 29},
       {u"a_b_c", {Point{0, 0}}, {0, 2, 4}, 26},
       {u"abc", {Point{0, 6}}, {0, 1, 2}, 20},
+    }));
+  }
+
+  {
+    TextBuffer buffer{u"abc Abc"};
+
+    REQUIRE(buffer.find_words_with_subsequence_in_range(u"Abc", u"", Range{Point{0, 0}, Point{0, UINT32_MAX}}) == vector<SubsequenceMatch>({
+      {u"Abc", {Point{0, 4}}, {0, 1, 2}, 20},
+      {u"abc", {Point{0, 0}}, {0, 1, 2}, 19}
     }));
   }
 }


### PR DESCRIPTION
This change addresses item#2 in https://github.com/atom/superstring/issues/36. This was the most minimal change I could think of that would get the desired result. I suppose we could make it even more strict and only add case sensitivity to the first letter of the word, but it seemed elegant and desirable to make it apply to all subword starts.

/cc @maxbrunsfeld @nathansobo 