### PR TITLE
Limit subsequence matches to words of 80 chars or less

### DIFF
--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -405,6 +405,7 @@ struct TextBuffer::Layer {
   };
 
   vector<SubsequenceMatch> find_words_with_subsequence_in_range(u16string query, const u16string &extra_word_characters, Range range) {
+    const size_t MAX_WORD_LENGTH = 80;
     size_t query_index = 0;
     Point position;
     Point current_word_start;
@@ -431,7 +432,7 @@ struct TextBuffer::Layer {
           }
         } else {
           if (!current_word.empty()) {
-            if (query_index == query.size()) {
+            if (query_index == query.size() && current_word.size() <= MAX_WORD_LENGTH) {
               substring_matches[current_word].push_back(current_word_start);
             }
             query_index = 0;
@@ -450,7 +451,7 @@ struct TextBuffer::Layer {
       return false;
     });
 
-    if (!current_word.empty() && query_index == query.size()) {
+    if (!current_word.empty() && query_index == query.size() && current_word.size() <= MAX_WORD_LENGTH) {
       substring_matches[current_word].push_back(current_word_start);
     }
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1150,6 +1150,17 @@ describe('TextBuffer', () => {
         ])
       })
     })
+
+    it.only('does not compute matches for words longer than 80 characters', () => {
+      const buffer = new TextBuffer('eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2xpYi9jb252ZXJ0LmpzIl0sIm5hbWVzIjpbImxzi')
+      const buffer2 = new TextBuffer('eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2xpYi9jb252ZXJ0LmpzIl0sIm5hbWVzIjpbImxz')
+      return buffer.findWordsWithSubsequence('eyJ', '', 1).then(results => {
+        assert.equal(results.length, 0)
+        return buffer2.findWordsWithSubsequence('eyJ', '', 1).then(results => {
+          assert.equal(results.length, 1)
+        })
+      })
+    })
   })
 
   describe('.reset', () => {

--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -432,6 +432,14 @@ TEST_CASE("TextBuffer::find_words_with_subsequence_in_range") {
       {u"abc", {Point{0, 0}}, {0, 1, 2}, 19}
     }));
   }
+
+  {
+    // Does not match words longer than 80 characters
+    TextBuffer buffer{u"eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2xpYi9jb252ZXJ0LmpzIl0sIm5hbWVzIjpbImxzi"};
+
+    REQUIRE(buffer.find_words_with_subsequence_in_range(u"eyJ", u"", Range{Point{0, 0}, Point{0, UINT32_MAX}}) == vector<SubsequenceMatch>({
+    }));
+  }
 }
 
 struct SnapshotData {


### PR DESCRIPTION
fix https://github.com/atom/superstring/issues/39