### PR TITLE
Handle regexes with unicode escape sequences in .find and .findAll

### DIFF
--- a/src/bindings/em/auto-wrap.h
+++ b/src/bindings/em/auto-wrap.h
@@ -162,31 +162,31 @@ struct em_wrap_type<MarkerIndex::BoundaryQueryResult> : public em_wrap_type_base
 };
 
 template <>
-struct em_wrap_type<Text> : public em_wrap_type_base<Text, std::string> {
-  static Text receive(std::string const &str) {
+struct em_wrap_type<Text> : public em_wrap_type_base<Text, std::wstring> {
+  static Text receive(std::wstring const &str) {
     return Text(str.begin(), str.end());
   }
 
-  static std::string transmit(Text const &text) {
-    return std::string(text.begin(), text.end());
+  static std::wstring transmit(Text const &text) {
+    return std::wstring(text.begin(), text.end());
   }
 };
 
 template <>
-struct em_wrap_type<std::u16string> : public em_wrap_type_base<std::u16string, std::string> {
-  static std::u16string receive(std::string const &str) {
+struct em_wrap_type<std::u16string> : public em_wrap_type_base<std::u16string, std::wstring> {
+  static std::u16string receive(std::wstring const &str) {
     return std::u16string(str.begin(), str.end());
   }
 
-  static std::string transmit(std::u16string const &text) {
-    return std::string(text.begin(), text.end());
+  static std::wstring transmit(std::u16string const &text) {
+    return std::wstring(text.begin(), text.end());
   }
 };
 
 template <>
 struct em_wrap_type<Text *> : public em_wrap_type_base<Text *, emscripten::val> {
   static Text * receive(emscripten::val const &value) {
-    return new Text(em_wrap_type<Text>::receive(value.as<std::string>()));
+    return new Text(em_wrap_type<Text>::receive(value.as<std::wstring>()));
   }
 
   static emscripten::val transmit(Text *text) {

--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -5,11 +5,11 @@
 using std::string;
 using std::u16string;
 
-static TextBuffer *construct(const std::string &text) {
+static TextBuffer *construct(const std::wstring &text) {
   return new TextBuffer(u16string(text.begin(), text.end()));
 }
 
-static emscripten::val find_sync(TextBuffer &buffer, std::string js_pattern, Range range) {
+static emscripten::val find_sync(TextBuffer &buffer, std::wstring js_pattern, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
   Regex regex(pattern, &error_message);
@@ -25,7 +25,7 @@ static emscripten::val find_sync(TextBuffer &buffer, std::string js_pattern, Ran
   return emscripten::val::null();
 }
 
-static emscripten::val find_all_sync(TextBuffer &buffer, std::string js_pattern, Range range) {
+static emscripten::val find_all_sync(TextBuffer &buffer, std::wstring js_pattern, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
   Regex regex(pattern, &error_message);

--- a/src/core/regex.cc
+++ b/src/core/regex.cc
@@ -1,4 +1,5 @@
 #include "regex.h"
+#include <stdlib.h>
 #include "pcre2.h"
 
 using std::u16string;
@@ -8,17 +9,50 @@ const char16_t EMPTY_PATTERN[] = u".{0}";
 
 Regex::Regex() : code{nullptr} {}
 
+static u16string preprocess_pattern(const char16_t *pattern, uint32_t length) {
+  u16string result;
+  for (unsigned i = 0; i < length;) {
+    char16_t c = pattern[i];
+
+    // Replace escape sequences like '\u00cf' with their literal UTF16 value
+    if (c == '\\' && i + 1 < length && pattern[i + 1] == 'u') {
+      if (i + 6 <= length) {
+        std::string char_code_string(&pattern[i + 2], &pattern[i + 6]);
+        char16_t char_code_value = strtol(char_code_string.data(), nullptr, 16);
+        if (char_code_value != 0) {
+          result += char_code_value;
+          i += 6;
+          continue;
+        }
+      }
+
+      // Replace invalid '\u' escape sequences with the literal characters '\' and 'u'
+      result += u"\\\\u";
+      i += 2;
+      continue;
+    }
+
+    result += c;
+    i++;
+  }
+
+  return result;
+}
+
+
 Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_message) {
   if (pattern_length == 0) {
     pattern = EMPTY_PATTERN;
     pattern_length = 4;
   }
 
+  u16string final_pattern = preprocess_pattern(pattern, pattern_length);
+
   int error_number = 0;
   size_t error_offset = 0;
   code = pcre2_compile(
-    reinterpret_cast<const uint16_t *>(pattern),
-    pattern_length,
+    reinterpret_cast<const uint16_t *>(final_pattern.data()),
+    final_pattern.size(),
     PCRE2_MULTILINE,
     &error_number,
     &error_offset,

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -893,14 +893,14 @@ describe('TextBuffer', () => {
 
       try {
         buffer.findSync('[')
-        assert(false, 'Expected an exceptoin')
+        assert(false, 'Expected an exception')
       } catch (error) {
         assert.match(error.message, /missing terminating ] for character class/)
       }
 
       try {
         await buffer.find('[')
-        assert(false, 'Expected an exceptoin')
+        assert(false, 'Expected an exception')
       } catch (error) {
         assert.match(error.message, /missing terminating ] for character class/)
       }
@@ -920,6 +920,21 @@ describe('TextBuffer', () => {
       buffer.setTextInRange(Range(Point(0, 0), Point(0, 0)), ' ')
       assert.deepEqual(buffer.findSync(regex), Range(Point(0, 3), Point(0, 4)))
       assert.deepEqual(await buffer.find(regex), Range(Point(0, 3), Point(0, 4)))
+    })
+
+    it('supports regexes with unicode escape sequences', () => {
+      const buffer = new TextBuffer('åå é')
+      assert.equal('\u00e5', 'å')
+      assert.deepEqual(buffer.findSync('\u00e5+'), Range(Point(0, 0), Point(0, 2)))
+      assert.deepEqual(buffer.findSync(/\u00e5+/), Range(Point(0, 0), Point(0, 2)))
+
+      // Like with JS regexes, invalid unicode escape sequences just match their literal content.
+      assert.equal(buffer.findSync(/\uxxxx/), null)
+      buffer.setText('a \\uxxxx b')
+      assert.deepEqual(buffer.findSync(/\uxxxx/), Range(Point(0, 2), Point(0, 8)))
+
+      assert.deepEqual(buffer.findSync(/\uxxx/), Range(Point(0, 2), Point(0, 7)))
+      assert.deepEqual(buffer.findSync(/\uxx/), Range(Point(0, 2), Point(0, 6)))
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/16126

#### Background

The `TextBuffer.find` family of methods use PCRE to perform regex matching directly on the buffer's native contents. This has a number of advantages: it eliminates a lot of string copying, removes to need for conversions between raw character indices and row/column coordinates, and allows searching to be done on a background thread if desired. See #5, #35.

#### Problem

There are some differences between PCRE's and ECMAScript's regex syntax. One difference is that PCRE does not support the `\u00df` syntax for specifying UTF16 code points.

#### Solution

Luckily, it's trivial to convert these character sequences into their actual UTF16 values. I've added that conversion in this PR. 

#### Future Work

There may be other incompatibilities between PCRE and ECMAScript regexes. One other example I know of is the [unicode code point escape sequence](https://mathiasbynens.be/notes/javascript-escapes#unicode-code-point), which are slightly different than the UTF16 character code escape sequences I've dealt with here. They should be easy to support as well, though I have not done so here.

/cc @t9md