### PR TITLE
Cancel queued findWordsWithSubsequence jobs when mutating a buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,6 +231,11 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   TextBuffer.prototype.findWordsWithSubsequenceInRange = function (query, extraWordCharacters, maxCount, range) {
     return new Promise(resolve =>
       findWordsWithSubsequenceInRange.call(this, query, extraWordCharacters, maxCount, range, (matches, positions) => {
+        if (!matches) {
+          resolve(null)
+          return
+        }
+
         let positionArrayIndex = 0
         for (let i = 0, n = matches.length; i < n; i++) {
           let positionCount = positions[positionArrayIndex++]

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -3,11 +3,18 @@
 
 #include "nan.h"
 #include "text-buffer.h"
+#include <unordered_set>
+
+class CancellableWorker {
+public:
+  virtual void CancelIfQueued() = 0;
+};
 
 class TextBufferWrapper : public Nan::ObjectWrap {
 public:
   static void init(v8::Local<v8::Object> exports);
   TextBuffer text_buffer;
+  std::unordered_set<CancellableWorker *> outstanding_workers;
 
 private:
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info);
@@ -40,6 +47,8 @@ private:
   static void reset(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void base_text_digest(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void dot_graph(const Nan::FunctionCallbackInfo<v8::Value> &info);
+
+  void cancel_queued_workers();
 };
 
 #endif // SUPERSTRING_TEXT_BUFFER_WRAPPER_H

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -111,6 +111,11 @@ struct TextBuffer::Layer {
         preceding_change->new_start.traverse(position_within_preceding_change.position),
         preceding_change_current_offset + position_within_preceding_change.offset
       };
+    } else if (position == preceding_change->new_end) {
+      return {
+        position,
+        preceding_change_current_offset + preceding_change->new_text->size()
+      };
     } else {
       ClipResult base_location = previous_layer->clip_position(
         preceding_change->old_end.traverse(position.traversal(preceding_change->new_end))
@@ -776,7 +781,7 @@ void TextBuffer::set_text_in_range(Range old_range, u16string &&string) {
   }
 
   auto start = clip_position(old_range.start);
-  auto end = clip_position(old_range.end);
+  auto end = old_range.end == old_range.start ? start : clip_position(old_range.end);
   Point deleted_extent = end.position.traversal(start.position);
   Text new_text{move(string)};
   Point inserted_extent = new_text.extent();

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -470,6 +470,7 @@ struct TextBuffer::Layer {
     static const unsigned subword_start_with_case_mismatch_bonus = 9;
     static const unsigned mismatch_penalty = 1;
     static const unsigned leading_mismatch_penalty = 3;
+    static const unsigned max_variant_count = 100;
 
     vector<SubsequenceMatch> matches;
 
@@ -504,6 +505,14 @@ struct TextBuffer::Layer {
               }
 
               new_match.match_indices.push_back(i);
+
+              // If there are already too many match variants, then treat the current
+              // character as a match for this variant, rather than treating it as
+              // a mismatch and adding a *new* variant to represent the match.
+              if (match_variants.size() > max_variant_count) {
+                match_variants[j] = new_match;
+                continue;
+              }
 
               match_variants.push_back(new_match);
             }

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1216,16 +1216,20 @@ describe('TextBuffer', () => {
       const buffer = new TextBuffer(text + '\n')
       const promises = []
 
-      for (let i = 0; i < 25; i++) {
-        const position = buffer.getExtent()
+      for (let i = 0; i < 50; i++) {
+        const row = random(buffer.getLineCount())
+        const column = random(buffer.lineLengthForRow(row))
+        const position = {row, column}
         buffer.setTextInRange({start: position, end: position}, 'x')
-        promises.push(buffer.findWordsWithSubsequence('e', '', 1))
+        const text = buffer.getText()
+        promises.push(buffer.findWordsWithSubsequence('e', '', 1).then(matches => ({matches, text})))
       }
 
       return Promise.all(promises).then(subsequenceMatchResults => {
-        for (const matches of subsequenceMatchResults) {
+        for (const {matches, text} of subsequenceMatchResults) {
           // If the search was cancelled, `findWordsWithSubsequence` will resolve with `null`.
           if (matches) {
+            const buffer = new TextBuffer(text)
             for (const match of matches) {
               for (const position of match.positions) {
                 assert.equal(

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1039,6 +1039,31 @@ describe('TextBuffer', () => {
         }
       }
     })
+
+    it('can be called repeatedly between buffer mutations without harming performance', () => {
+      let seed = Date.now()
+      const random = new Random(seed)
+
+      let text = ''
+      for (let i = 0; i < 10000; i++) {
+        text += words[random.intBetween(0, words.length)]
+        text += random(5) === 0 ? '\n' : ' '
+      }
+
+      const buffer = new TextBuffer(text + '\n')
+      const promises = []
+
+      for (let i = 0; i < 25; i++) {
+        const row = random(buffer.getLineCount())
+        const column = random(buffer.lineLengthForRow(row))
+        const position = {row, column}
+        buffer.setTextInRange({start: position, end: position}, 'x')
+        buffer.lineLengthForRow(row)
+        promises.push(buffer.findAll(/e/))
+      }
+
+      return Promise.all(promises)
+    })
   })
 
   describe('.findAllInRange (sync and async)', () => {
@@ -1183,7 +1208,7 @@ describe('TextBuffer', () => {
       const random = new Random(seed)
 
       let text = ''
-      for (let i = 0; i < 100; i++) {
+      for (let i = 0; i < 1000; i++) {
         text += words[random.intBetween(0, words.length)]
         text += random(5) === 0 ? '\n' : ' '
       }

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1216,13 +1216,19 @@ describe('TextBuffer', () => {
       const buffer = new TextBuffer(text + '\n')
       const promises = []
 
-      for (let i = 0; i < 50; i++) {
-        const row = random(buffer.getLineCount())
-        const column = random(buffer.lineLengthForRow(row))
-        const position = {row, column}
+      const row = random(buffer.getLineCount())
+      const column = random(buffer.lineLengthForRow(row))
+      const position = {row, column}
+      buffer.setTextInRange({start: position, end: position}, ' ')
+      position.column++
+
+      // Simulate typing one character repeatedly
+      let query = ''
+      for (let i = 0; i < 100; i++) {
         buffer.setTextInRange({start: position, end: position}, 'x')
+        query += 'x'
         const text = buffer.getText()
-        promises.push(buffer.findWordsWithSubsequence('e', '', 1).then(matches => ({matches, text})))
+        promises.push(buffer.findWordsWithSubsequence(query, '', 1).then(matches => ({matches, text})))
       }
 
       return Promise.all(promises).then(subsequenceMatchResults => {


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/16153
Fixes https://github.com/atom/atom/issues/16159
Fixes atom/language-shellscript#88

#### Background

After enabling the new *Subsequence* autocomplete provider by default in Atom, we observed a bad slow-down when holding down an alphanumeric key. This was happening because we would were calling `findWordsWithSubsequence` many times in rapid succession, interspersed with buffer changes. This was resulting in a large number of text buffer layers being created.

#### Solution

We have made two changes to fix this problem:

1. When mutating a `TextBuffer`, we now cancel any `findWordsWithSubsequence` jobs that were initiated before the mutation and are still queued. Those calls will then resolve with `null`. This is ok because the result of those calls is no longer needed - a character has been typed since they were performed.

2. We have optimized the internal `TextBuffer::clip_position` method so that in one very common case, its cost will now scale *linearly* with number of buffer layers. Previously it accidentally scaled  *exponentially* with the number of layers because each layer would call `clip_position` twice on its underlying layer.