### PR TITLE
Avoid creating redundant match variants in findWordsWithSubsequence

### DIFF
--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1192,6 +1192,36 @@ describe('TextBuffer', () => {
       })
     })
 
+    it('prioritizes words in which beginnings of subwords match the query', async () => {
+      const buffer = new TextBuffer(`
+        leading_mismatch_penalty
+        partial_match_position
+        clampedRange
+      `)
+
+      assert.deepEqual((await buffer.findWordsWithSubsequence('lmp', '_', 3)).map(({word}) => word), [
+        'leading_mismatch_penalty',
+        'partial_match_position',
+        'clampedRange',
+      ])
+    })
+
+    it('prioritizes words in which consecutive letters match the query', async () => {
+      const buffer = new TextBuffer(`
+        deserialize
+        deserializer
+        savePromise
+        savePromises
+      `)
+
+      assert.deepEqual((await buffer.findWordsWithSubsequence('seri', '_', 4)).map(({word}) => word), [
+        'deserialize',
+        'deserializer',
+        'savePromise',
+        'savePromises',
+      ])
+    })
+
     it('does not compute matches for words longer than 80 characters', () => {
       const buffer = new TextBuffer('eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2xpYi9jb252ZXJ0LmpzIl0sIm5hbWVzIjpbImxzi')
       const buffer2 = new TextBuffer('eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi4uLy4uL2xpYi9jb252ZXJ0LmpzIl0sIm5hbWVzIjpbImxz')


### PR DESCRIPTION
This is a follow-up to #44.

This PR ensures that the memory and time used in `findWordsWithSubsequence` scales linearly with the length of the query, as opposed to exponentially. We have also removed the hard-coded limit on the number of match variants: a quick fix that we added in #44.