### PR TITLE
Handle failure to encode the unicode replacement character

### DIFF
--- a/src/core/encoding-conversion.cc
+++ b/src/core/encoding-conversion.cc
@@ -251,7 +251,13 @@ bool EncodingConversion::encode(const u16string &string, size_t start_offset,
       output_vector.size(),
       end
     );
-    if (bytes_encoded == 0) end = true;
+    if (bytes_encoded == 0) {
+      if (start_offset == end_offset) {
+        end = true;
+      } else {
+        return false;
+      }
+    }
     size_t bytes_written = fwrite(output_buffer, 1, bytes_encoded, stream);
     if (bytes_written < bytes_encoded && ferror(stream)) return false;
   }

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -647,6 +647,21 @@ describe('TextBuffer', () => {
           })
       })
 
+      it('rejects if neither the text nor the replacement character can be represented in the given encoding', (done) => {
+        const buffer = new TextBuffer('💪💪💪')
+        const {path: filePath} = temp.openSync()
+        return buffer.save(filePath, 'iso88591')
+          .then(() => {
+            done(new Error('Expected an error'))
+          })
+          .catch((error) => {
+            assert.include(error.message, ' write ')
+            assert.equal(error.code, 'EILSEQ')
+            assert.equal(error.path, filePath)
+            done()
+          })
+      })
+
       it('rejects with an error if writing to a stream fails', (done) => {
         const tempDir = temp.mkdirSync()
         const filePath = path.join(tempDir, 'one')


### PR DESCRIPTION
Fixes https://github.com/atom/superstring/issues/47

When the buffer contains text that cannot be encoded in the desired encoding, we currently replace it with the [Unicode replacement character](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character). But that character can't be encoded in some encodings. Previously, failing to encode the replacement character would result in an infinite loop.

Now `TextBuffer.save` will reject with an `EILSEQ` (invalid byte sequence) error.