### PR TITLE
Fix some regex search bugs

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,12 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   const DEFAULT_RANGE = Object.freeze({start: {row: 0, column: 0}, end: {row: Infinity, column: Infinity}})
 
   TextBuffer.prototype.findInRangeSync = function (pattern, range) {
-    if (pattern.source) pattern = pattern.source
-    const result = findSync.call(this, pattern, range)
+    let ignoreCase = false
+    if (pattern.source) {
+      ignoreCase = pattern.flags.includes('i')
+      pattern = pattern.source
+    }
+    const result = findSync.call(this, pattern, ignoreCase, range)
     if (typeof result === 'string') {
       throw new Error(result);
     } else {
@@ -22,8 +26,12 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   }
 
   TextBuffer.prototype.findAllInRangeSync = function (pattern, range) {
-    if (pattern.source) pattern = pattern.source
-    const result = findAllSync.call(this, pattern, range)
+    let ignoreCase = false
+    if (pattern.source) {
+      ignoreCase = pattern.flags.includes('i')
+      pattern = pattern.source
+    }
+    const result = findAllSync.call(this, pattern, ignoreCase, range)
     if (typeof result === 'string') {
       throw new Error(result);
     } else {

--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -9,10 +9,10 @@ static TextBuffer *construct(const std::wstring &text) {
   return new TextBuffer(u16string(text.begin(), text.end()));
 }
 
-static emscripten::val find_sync(TextBuffer &buffer, std::wstring js_pattern, Range range) {
+static emscripten::val find_sync(TextBuffer &buffer, std::wstring js_pattern, bool ignore_case, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
-  Regex regex(pattern, &error_message);
+  Regex regex(pattern, &error_message, ignore_case);
   if (!error_message.empty()) {
     return emscripten::val(string(error_message.begin(), error_message.end()));
   }
@@ -25,10 +25,10 @@ static emscripten::val find_sync(TextBuffer &buffer, std::wstring js_pattern, Ra
   return emscripten::val::null();
 }
 
-static emscripten::val find_all_sync(TextBuffer &buffer, std::wstring js_pattern, Range range) {
+static emscripten::val find_all_sync(TextBuffer &buffer, std::wstring js_pattern, bool ignore_case, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
-  Regex regex(pattern, &error_message);
+  Regex regex(pattern, &error_message, ignore_case);
   if (!error_message.empty()) {
     return emscripten::val(string(error_message.begin(), error_message.end()));
   }

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -82,6 +82,7 @@ class RegexWrapper : public Nan::ObjectWrap {
     Local<String> js_pattern;
     Local<RegExp> js_regex;
     Local<String> cache_key = Nan::New("__textBufferRegex").ToLocalChecked();
+    bool ignore_case = false;
 
     if (value->IsString()) {
       js_pattern = Local<String>::Cast(value);
@@ -92,6 +93,7 @@ class RegexWrapper : public Nan::ObjectWrap {
         return &Nan::ObjectWrap::Unwrap<RegexWrapper>(stored_regex->ToObject())->regex;
       }
       js_pattern = js_regex->GetSource();
+      if (js_regex->GetFlags() & RegExp::kIgnoreCase) ignore_case = true;
     } else {
       Nan::ThrowTypeError("Argument must be a RegExp");
       return nullptr;
@@ -99,7 +101,7 @@ class RegexWrapper : public Nan::ObjectWrap {
 
     u16string error_message;
     optional<u16string> pattern = string_conversion::string_from_js(js_pattern);
-    Regex regex(*pattern, &error_message);
+    Regex regex(*pattern, &error_message, ignore_case);
     if (!error_message.empty()) {
       Nan::ThrowError(string_conversion::string_to_js(error_message));
       return nullptr;

--- a/src/core/point.cc
+++ b/src/core/point.cc
@@ -66,6 +66,10 @@ bool Point::operator==(const Point &other) const {
   return compare(other) == 0;
 }
 
+bool Point::operator!=(const Point &other) const {
+  return compare(other) != 0;
+}
+
 bool Point::operator<(const Point &other) const {
   return compare(other) < 0;
 }

--- a/src/core/point.h
+++ b/src/core/point.h
@@ -22,6 +22,7 @@ struct Point {
   Point traversal(const Point &other) const;
   void serialize(Serializer &output) const;
 
+  bool operator!=(const Point &other) const;
   bool operator==(const Point &other) const;
   bool operator<(const Point &other) const;
   bool operator<=(const Point &other) const;

--- a/src/core/regex.cc
+++ b/src/core/regex.cc
@@ -40,7 +40,7 @@ static u16string preprocess_pattern(const char16_t *pattern, uint32_t length) {
 }
 
 
-Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_message) {
+Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_message, bool ignore_case) {
   if (pattern_length == 0) {
     pattern = EMPTY_PATTERN;
     pattern_length = 4;
@@ -50,10 +50,12 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
 
   int error_number = 0;
   size_t error_offset = 0;
+  uint32_t options = PCRE2_MULTILINE;
+  if (ignore_case) options |= PCRE2_CASELESS;
   code = pcre2_compile(
     reinterpret_cast<const uint16_t *>(final_pattern.data()),
     final_pattern.size(),
-    PCRE2_MULTILINE,
+    options,
     &error_number,
     &error_offset,
     nullptr
@@ -72,8 +74,8 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
   );
 }
 
-Regex::Regex(const u16string &pattern, u16string *error_message)
-  : Regex(pattern.data(), pattern.size(), error_message) {}
+Regex::Regex(const u16string &pattern, u16string *error_message, bool ignore_case)
+  : Regex(pattern.data(), pattern.size(), error_message, ignore_case) {}
 
 Regex::Regex(Regex &&other) : code{other.code} {
   other.code = nullptr;

--- a/src/core/regex.h
+++ b/src/core/regex.h
@@ -14,8 +14,8 @@ class Regex {
 
  public:
   Regex();
-  Regex(const char16_t *, uint32_t, std::u16string *error_message);
-  Regex(const std::u16string &, std::u16string *error_message);
+  Regex(const char16_t *, uint32_t, std::u16string *error_message, bool ignore_case = false);
+  Regex(const std::u16string &, std::u16string *error_message, bool ignore_case = false);
   Regex(Regex &&);
   ~Regex();
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1001,6 +1001,15 @@ describe('TextBuffer', () => {
       ])
     })
 
+    it('handles the case-insensitive flag', () => {
+      const buffer = new TextBuffer('aB\nab\nac')
+
+      assert.deepEqual(buffer.findAllSync(/ab/i), [
+        Range(Point(0, 0), Point(0, 2)),
+        Range(Point(1, 0), Point(1, 2)),
+      ])
+    })
+
     it('returns the same results as a reference implementation', () => {
       for (let i = 0; i < 3; i++) {
         const generateSeed = Random.create()

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -997,7 +997,25 @@ describe('TextBuffer', () => {
 
       assert.deepEqual(buffer.findAllSync(/^[ \t\r]*$/), [
         Range(Point(1, 0), Point(1, 0)),
-        Range(Point(3, 0), Point(3, 0))
+        Range(Point(3, 0), Point(3, 0)),
+        Range(Point(4, 0), Point(4, 0))
+      ])
+    })
+
+    it('handles patterns that match the empty string (regression)', () => {
+      const buffer = new TextBuffer('aaab\nab\nb')
+      assert.deepEqual(buffer.findAllSync(/^a*/), [
+        Range(Point(0, 0), Point(0, 3)),
+        Range(Point(1, 0), Point(1, 1)),
+        Range(Point(2, 0), Point(2, 0))
+      ])
+
+      buffer.setText('aaab\nab\nb\n')
+      assert.deepEqual(buffer.findAllSync(/^a*/), [
+        Range(Point(0, 0), Point(0, 3)),
+        Range(Point(1, 0), Point(1, 1)),
+        Range(Point(2, 0), Point(2, 0)),
+        Range(Point(3, 0), Point(3, 0)),
       ])
     })
 

--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -404,6 +404,29 @@ TEST_CASE("TextBuffer::find_all") {
   }));
 }
 
+TEST_CASE("TextBuffer::find_all - empty matches") {
+  TextBuffer buffer{u"aab\nab\nb\n"};
+  REQUIRE(buffer.find_all(Regex(u"^a*", nullptr)) == vector<Range>({
+    Range{Point{0, 0}, Point{0, 2}},
+    Range{Point{1, 0}, Point{1, 1}},
+    Range{Point{2, 0}, Point{2, 0}},
+    Range{Point{3, 0}, Point{3, 0}},
+  }));
+
+  REQUIRE(buffer.find_all(Regex(u"^a*", nullptr), {{1, 0}, {2, 0}}) == vector<Range>({
+    Range{Point{1, 0}, Point{1, 1}},
+    Range{Point{2, 0}, Point{2, 0}},
+  }));
+
+  buffer.set_text(u"abc");
+  REQUIRE(buffer.find_all(Regex(u"", nullptr)) == vector<Range>({
+    Range{Point{0, 0}, Point{0, 0}},
+    Range{Point{0, 1}, Point{0, 1}},
+    Range{Point{0, 2}, Point{0, 2}},
+    Range{Point{0, 3}, Point{0, 3}},
+  }));
+}
+
 TEST_CASE("TextBuffer::find_words_with_subsequence_in_range") {
   {
     TextBuffer buffer{u"banana band bandana banana"};


### PR DESCRIPTION
Previously, we did not handle case insensitive regexes (e.g. `/foo/i`). There was also a bug in the handling of regexes that match the empty string.