### PR TITLE
Add TextBuffer.findAndMarkInRangeSync method

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   binding = require('./browser');
 
   const {TextBuffer, Patch} = binding
-  const {findSync, findAllSync, findWordsWithSubsequenceInRange} = TextBuffer.prototype
+  const {findSync, findAllSync, findAndMarkAllSync, findWordsWithSubsequenceInRange} = TextBuffer.prototype
   const DEFAULT_RANGE = Object.freeze({start: {row: 0, column: 0}, end: {row: Infinity, column: Infinity}})
 
   TextBuffer.prototype.findInRangeSync = function (pattern, range) {
@@ -38,9 +38,26 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
       return result
     }
   }
-
   TextBuffer.prototype.findAllSync = function (pattern, range) {
     return this.findAllInRangeSync(pattern, DEFAULT_RANGE)
+  }
+
+  TextBuffer.prototype.findAndMarkAllInRangeSync = function (markerIndex, nextId, exclusive, pattern, range) {
+    let ignoreCase = false
+    if (pattern.source) {
+      ignoreCase = pattern.flags.includes('i')
+      pattern = pattern.source
+    }
+    const result = findAndMarkAllSync.call(this, markerIndex, nextId, exclusive, pattern, ignoreCase, range)
+    if (typeof result === 'string') {
+      throw new Error(result);
+    } else {
+      return result
+    }
+  }
+
+  TextBuffer.prototype.findAndMarkAllSync = function (markerIndex, nextId, exclusive, pattern) {
+    return this.findAndMarkAllInRangeSync(markerIndex, nextId, exclusive, pattern, DEFAULT_RANGE)
   }
 
   TextBuffer.prototype.find = function (pattern) {

--- a/src/bindings/marker-index-wrapper.cc
+++ b/src/bindings/marker-index-wrapper.cc
@@ -10,6 +10,7 @@
 using namespace v8;
 using std::unordered_map;
 
+static Nan::Persistent<v8::FunctionTemplate> marker_index_constructor_template;
 static Nan::Persistent<String> start_string;
 static Nan::Persistent<String> end_string;
 static Nan::Persistent<String> touch_string;
@@ -68,7 +69,16 @@ void MarkerIndexWrapper::init(Local<Object> exports) {
   starting_string.Reset(Nan::Persistent<String>(Nan::New("starting").ToLocalChecked()));
   ending_string.Reset(Nan::Persistent<String>(Nan::New("ending").ToLocalChecked()));
 
+  marker_index_constructor_template.Reset(constructor_template);
   exports->Set(Nan::New("MarkerIndex").ToLocalChecked(), constructor_template->GetFunction());
+}
+
+MarkerIndex *MarkerIndexWrapper::from_js(Local<Value> value) {
+  auto js_marker_index = Local<Object>::Cast(value);
+  if (!Nan::New(marker_index_constructor_template)->HasInstance(js_marker_index)) {
+    return nullptr;
+  }
+  return &Nan::ObjectWrap::Unwrap<MarkerIndexWrapper>(js_marker_index)->marker_index;
 }
 
 void MarkerIndexWrapper::construct(const Nan::FunctionCallbackInfo<Value> &info) {

--- a/src/bindings/marker-index-wrapper.h
+++ b/src/bindings/marker-index-wrapper.h
@@ -6,6 +6,7 @@
 class MarkerIndexWrapper : public Nan::ObjectWrap {
 public:
   static void init(v8::Local<v8::Object> exports);
+  static MarkerIndex *from_js(v8::Local<v8::Value>);
 
 private:
   static void construct(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -35,6 +35,7 @@ private:
   static void find_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_all(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_all_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void find_and_mark_all_sync(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void find_words_with_subsequence_in_range(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void is_modified(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void load(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -417,6 +417,18 @@ struct TextBuffer::Layer {
     return result;
   }
 
+  unsigned find_and_mark_all_in_range(MarkerIndex &index, MarkerIndex::MarkerId first_id,
+                                      bool exclusive, const Regex &regex, Range range, bool splay = false) {
+    unsigned id = first_id;
+    scan_in_range(regex, range, [&index, &id, exclusive](Range match_range) -> bool {
+      index.insert(id, match_range.start, match_range.end);
+      index.set_exclusive(id, exclusive);
+      id++;
+      return false;
+    }, splay);
+    return id - first_id;
+  }
+
   struct SubsequenceMatchVariant {
     size_t query_index = 0;
     std::vector<uint32_t> match_indices;
@@ -885,6 +897,11 @@ optional<Range> TextBuffer::find(const Regex &regex, Range range) const {
 
 vector<Range> TextBuffer::find_all(const Regex &regex, Range range) const {
   return top_layer->find_all_in_range(regex, range, false);
+}
+
+unsigned TextBuffer::find_and_mark_all(MarkerIndex &index, MarkerIndex::MarkerId next_id,
+                                       bool exclusive, const Regex &regex, Range range) const {
+  return top_layer->find_and_mark_all_in_range(index, next_id, exclusive, regex, range, false);
 }
 
 bool TextBuffer::SubsequenceMatch::operator==(const SubsequenceMatch &other) const {

--- a/src/core/text-buffer.h
+++ b/src/core/text-buffer.h
@@ -8,6 +8,7 @@
 #include "point.h"
 #include "range.h"
 #include "regex.h"
+#include "marker-index.h"
 
 class TextBuffer {
   struct Layer;
@@ -50,6 +51,8 @@ public:
 
   optional<Range> find(const Regex &, Range range = Range::all_inclusive()) const;
   std::vector<Range> find_all(const Regex &, Range range = Range::all_inclusive()) const;
+  unsigned find_and_mark_all(MarkerIndex &, MarkerIndex::MarkerId, bool exclusive,
+                             const Regex &, Range range = Range::all_inclusive()) const;
 
   struct SubsequenceMatch {
     std::u16string word;

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -3,7 +3,7 @@ const path = require('path')
 const temp = require('temp').track()
 const {Writable} = require('stream')
 const {assert} = require('chai')
-const {TextBuffer} = require('../..')
+const {TextBuffer, MarkerIndex} = require('../..')
 const Random = require('random-seed')
 const TestDocument = require('./helpers/test-document')
 const {traverse} = require('./helpers/point-helpers')
@@ -1159,6 +1159,21 @@ describe('TextBuffer', () => {
       assert.deepEqual(buffer.findAllInRangeSync(/\w\r?$/, Range(Point(2, 1), Point(2, Infinity))), [
         Range(Point(2, 4), Point(2, 5))
       ])
+    })
+  })
+
+  describe('.findAndMarkAllSync', () => {
+    it('stores all of the matching ranges in the given marker index', () => {
+      const markerIndex = new MarkerIndex()
+      const buffer = new TextBuffer('abc def\nghi jkl\n')
+      const count = buffer.findAndMarkAllSync(markerIndex, 5, true, /\w+/)
+      assert.equal(count, 4)
+      assert.deepEqual(markerIndex.dump(), {
+        5: {start: {column: 0, row: 0}, end: {column: 3, row: 0}},
+        6: {start: {column: 4, row: 0}, end: {column: 7, row: 0}},
+        7: {start: {column: 0, row: 1}, end: {column: 3, row: 1}},
+        8: {start: {column: 4, row: 1}, end: {column: 7, row: 1}}
+      })
     })
   })
 


### PR DESCRIPTION
This method populates a marker index with the matching ranges instead of returning them in an array. This will make find and replace much faster by avoiding a lot of individual JavaScript calls to `MarkerIndex.insert` and `MarkerIndex.setExclusive`. It also paves the way to potentially adding an async variant of this method so that all of the work can be done in a background thread.

This isn't a bugfix, but it was a super easy follow-up to the bugfix work I did in https://github.com/atom/text-buffer/pull/288, so I thought I might as well go ahead and try it this morning.