### PR TITLE
Compute minimum_match_row after adjusting last_search_end_position

### DIFF
--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -362,7 +362,6 @@ struct TextBuffer::Layer {
               slice_to_search_start_position.traverse(match_end_position)
             };
 
-            minimum_match_row = last_match.end.row;
             last_search_end_position = last_match.end;
             if (match_end_position == match_start_position) {
               last_search_end_position.column++;
@@ -371,6 +370,7 @@ struct TextBuffer::Layer {
                 last_search_end_position.row++;
               }
             }
+            minimum_match_row = last_search_end_position.row;
 
             slice_to_search_start_position = last_search_end_position;
             if (slice_to_search_start_position >= chunk_start_position) {


### PR DESCRIPTION
If `last_search_end_position`'s row is adjusted, `minimum_match_row` becomes less than `slice_to_start_search_position.row` and the `min_row` passed to `TextSlice::position_for_offset()` overflows to a large, positive integer. If `start_position.row` is not large enough to wrap `start_position.row + min_row` back around, then the `line_offsets_begin` iterator in `Text::position_for_offset()` is moved beyond `line_offsets.end()` and the `std::upper_bound()` call fails with a segfault.

Here are the relevant methods:

##### TextBuffer::scan_in_range()

https://github.com/atom/superstring/blob/f5e365668391ef2af89a9a748a634fa619cdb85c/src/core/text-buffer.cc#L273-L398

##### TextSlice::position_for_offset()

https://github.com/atom/superstring/blob/f5e365668391ef2af89a9a748a634fa619cdb85c/src/core/text-slice.cc#L68-L73

##### Text::position_for_offset()

https://github.com/atom/superstring/blob/f5e365668391ef2af89a9a748a634fa619cdb85c/src/core/text.cc#L205-L216

What's interesting is that I couldn't actually get this to happen in a test case. I could see `min_row` overflowing, but the start position row was always enough to wrap it back around. Integer overflow behavior is in the realm of 👻 Undefined Behavior 👻 though so I wouldn't be unduly surprised if this was a fluke of my exact machine and compiler and such.

Hopefully deals with #57. :bug: introduced in #53.