### PR TITLE
Always treat \r and \n as newlines

### DIFF
--- a/src/core/regex.cc
+++ b/src/core/regex.cc
@@ -48,6 +48,9 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
 
   u16string final_pattern = preprocess_pattern(pattern, pattern_length);
 
+  pcre2_compile_context *context = pcre2_compile_context_create(nullptr);
+  pcre2_set_newline(context, PCRE2_NEWLINE_ANY);
+
   int error_number = 0;
   size_t error_offset = 0;
   uint32_t options = PCRE2_MULTILINE;
@@ -58,8 +61,9 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
     options,
     &error_number,
     &error_offset,
-    nullptr
+    context
   );
+  pcre2_compile_context_free(context);
 
   if (!code) {
     uint16_t message_buffer[256];

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1190,7 +1190,7 @@ describe('TextBuffer', () => {
 
     it('does not match \\r with .', () => {
       const buffer = new TextBuffer('\r')
-      assert.lengthOf(buffer.findAllInRangeSync(/./), 0)
+      assert.lengthOf(buffer.findAllInRangeSync(/./, Range(Point(0, 0), Point(Infinity, Infinity))), 0)
     })
   })
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1187,6 +1187,11 @@ describe('TextBuffer', () => {
         Range(Point(5, 0), Point(5, 0))
       ])
     })
+
+    it('does not match \\r with .', () => {
+      const buffer = new TextBuffer('\r')
+      assert.lengthOf(buffer.findAllInRangeSync(/./), 0)
+    })
   })
 
   describe('.findAndMarkAllSync', () => {


### PR DESCRIPTION
By [configuring pcre](http://www.pcre.org/current/doc/html/pcre2api.html#compilecontext) to recognize any unicode newline sequence, we can prevent `.` from matching `\r` on files with `\r\n` newlines. This makes superstring's regex matching more consistent with JavaScript's and avoids problems like atom/atom#17023, where a `scanInRange()` callback is triggered with a `null` match.