### PR TITLE
Enable unicode support in pcre

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
 
   TextBuffer.prototype.findInRangeSync = function (pattern, range) {
     let ignoreCase = false
+    let unicode = false
     if (pattern.source) {
       ignoreCase = pattern.flags.includes('i')
+      unicode = pattern.unicode
       pattern = pattern.source
     }
-    const result = findSync.call(this, pattern, ignoreCase, range)
+    const result = findSync.call(this, pattern, ignoreCase, unicode, range)
     if (typeof result === 'string') {
       throw new Error(result);
     } else {
@@ -27,11 +29,13 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
 
   TextBuffer.prototype.findAllInRangeSync = function (pattern, range) {
     let ignoreCase = false
+    let unicode = false
     if (pattern.source) {
       ignoreCase = pattern.flags.includes('i')
+      unicode = pattern.unicode
       pattern = pattern.source
     }
-    const result = findAllSync.call(this, pattern, ignoreCase, range)
+    const result = findAllSync.call(this, pattern, ignoreCase, unicode, range)
     if (typeof result === 'string') {
       throw new Error(result);
     } else {
@@ -44,11 +48,13 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
 
   TextBuffer.prototype.findAndMarkAllInRangeSync = function (markerIndex, nextId, exclusive, pattern, range) {
     let ignoreCase = false
+    let unicode = false
     if (pattern.source) {
       ignoreCase = pattern.flags.includes('i')
+      unicode = pattern.unicode
       pattern = pattern.source
     }
-    const result = findAndMarkAllSync.call(this, markerIndex, nextId, exclusive, pattern, ignoreCase, range)
+    const result = findAndMarkAllSync.call(this, markerIndex, nextId, exclusive, pattern, ignoreCase, unicode, range)
     if (typeof result === 'string') {
       throw new Error(result);
     } else {

--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -10,10 +10,10 @@ static TextBuffer *construct(const std::wstring &text) {
   return new TextBuffer(u16string(text.begin(), text.end()));
 }
 
-static emscripten::val find_sync(TextBuffer &buffer, std::wstring js_pattern, bool ignore_case, Range range) {
+static emscripten::val find_sync(TextBuffer &buffer, std::wstring js_pattern, bool ignore_case, bool unicode, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
-  Regex regex(pattern, &error_message, ignore_case);
+  Regex regex(pattern, &error_message, ignore_case, unicode);
   if (!error_message.empty()) {
     return emscripten::val(string(error_message.begin(), error_message.end()));
   }
@@ -26,10 +26,10 @@ static emscripten::val find_sync(TextBuffer &buffer, std::wstring js_pattern, bo
   return emscripten::val::null();
 }
 
-static emscripten::val find_all_sync(TextBuffer &buffer, std::wstring js_pattern, bool ignore_case, Range range) {
+static emscripten::val find_all_sync(TextBuffer &buffer, std::wstring js_pattern, bool ignore_case, bool unicode, Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
-  Regex regex(pattern, &error_message, ignore_case);
+  Regex regex(pattern, &error_message, ignore_case, unicode);
   if (!error_message.empty()) {
     return emscripten::val(string(error_message.begin(), error_message.end()));
   }
@@ -38,10 +38,11 @@ static emscripten::val find_all_sync(TextBuffer &buffer, std::wstring js_pattern
 }
 
 static emscripten::val find_and_mark_all_sync(TextBuffer &buffer, MarkerIndex &index, unsigned next_id,
-                                              bool exclusive, std::wstring js_pattern, bool ignore_case, Range range) {
+                                              bool exclusive, std::wstring js_pattern, bool ignore_case, bool unicode,
+                                              Range range) {
   u16string pattern(js_pattern.begin(), js_pattern.end());
   u16string error_message;
-  Regex regex(pattern, &error_message, ignore_case);
+  Regex regex(pattern, &error_message, ignore_case, unicode);
   if (!error_message.empty()) {
     return emscripten::val(string(error_message.begin(), error_message.end()));
   }

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -84,6 +84,7 @@ class RegexWrapper : public Nan::ObjectWrap {
     Local<RegExp> js_regex;
     Local<String> cache_key = Nan::New("__textBufferRegex").ToLocalChecked();
     bool ignore_case = false;
+    bool unicode = false;
 
     if (value->IsString()) {
       js_pattern = Local<String>::Cast(value);
@@ -95,6 +96,7 @@ class RegexWrapper : public Nan::ObjectWrap {
       }
       js_pattern = js_regex->GetSource();
       if (js_regex->GetFlags() & RegExp::kIgnoreCase) ignore_case = true;
+      if (js_regex->GetFlags() & RegExp::kUnicode) unicode = true;
     } else {
       Nan::ThrowTypeError("Argument must be a RegExp");
       return nullptr;
@@ -102,7 +104,7 @@ class RegexWrapper : public Nan::ObjectWrap {
 
     u16string error_message;
     optional<u16string> pattern = string_conversion::string_from_js(js_pattern);
-    Regex regex(*pattern, &error_message, ignore_case);
+    Regex regex(*pattern, &error_message, ignore_case, unicode);
     if (!error_message.empty()) {
       Nan::ThrowError(string_conversion::string_to_js(error_message));
       return nullptr;

--- a/src/core/regex.cc
+++ b/src/core/regex.cc
@@ -53,7 +53,7 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
 
   int error_number = 0;
   size_t error_offset = 0;
-  uint32_t options = PCRE2_MULTILINE;
+  uint32_t options = PCRE2_MULTILINE | PCRE2_UTF;
   if (ignore_case) options |= PCRE2_CASELESS;
   code = pcre2_compile(
     reinterpret_cast<const uint16_t *>(final_pattern.data()),

--- a/src/core/regex.cc
+++ b/src/core/regex.cc
@@ -48,9 +48,6 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
 
   u16string final_pattern = preprocess_pattern(pattern, pattern_length);
 
-  pcre2_compile_context *context = pcre2_compile_context_create(nullptr);
-  pcre2_set_newline(context, PCRE2_NEWLINE_ANY);
-
   int error_number = 0;
   size_t error_offset = 0;
   uint32_t options = PCRE2_MULTILINE | PCRE2_UTF;
@@ -61,9 +58,8 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
     options,
     &error_number,
     &error_offset,
-    context
+    nullptr
   );
-  pcre2_compile_context_free(context);
 
   if (!code) {
     uint16_t message_buffer[256];

--- a/src/core/regex.cc
+++ b/src/core/regex.cc
@@ -40,7 +40,7 @@ static u16string preprocess_pattern(const char16_t *pattern, uint32_t length) {
 }
 
 
-Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_message, bool ignore_case) {
+Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_message, bool ignore_case, bool unicode) {
   if (pattern_length == 0) {
     pattern = EMPTY_PATTERN;
     pattern_length = 4;
@@ -50,8 +50,9 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
 
   int error_number = 0;
   size_t error_offset = 0;
-  uint32_t options = PCRE2_MULTILINE | PCRE2_UTF;
+  uint32_t options = PCRE2_MULTILINE;
   if (ignore_case) options |= PCRE2_CASELESS;
+  if (unicode) options |= PCRE2_UTF;
   code = pcre2_compile(
     reinterpret_cast<const uint16_t *>(final_pattern.data()),
     final_pattern.size(),
@@ -74,8 +75,8 @@ Regex::Regex(const char16_t *pattern, uint32_t pattern_length, u16string *error_
   );
 }
 
-Regex::Regex(const u16string &pattern, u16string *error_message, bool ignore_case)
-  : Regex(pattern.data(), pattern.size(), error_message, ignore_case) {}
+Regex::Regex(const u16string &pattern, u16string *error_message, bool ignore_case, bool unicode)
+  : Regex(pattern.data(), pattern.size(), error_message, ignore_case, unicode) {}
 
 Regex::Regex(Regex &&other) : code{other.code} {
   other.code = nullptr;

--- a/src/core/regex.h
+++ b/src/core/regex.h
@@ -14,8 +14,8 @@ class Regex {
 
  public:
   Regex();
-  Regex(const char16_t *, uint32_t, std::u16string *error_message, bool ignore_case = false);
-  Regex(const std::u16string &, std::u16string *error_message, bool ignore_case = false);
+  Regex(const char16_t *, uint32_t, std::u16string *error_message, bool ignore_case = false, bool unicode = false);
+  Regex(const std::u16string &, std::u16string *error_message, bool ignore_case = false, bool unicode = false);
   Regex(Regex &&);
   ~Regex();
 

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1195,7 +1195,7 @@ describe('TextBuffer', () => {
 
     it('uses unicode properties for case equivalence', () => {
       const buffer = new TextBuffer('--- Április ---')
-      assert.deepEqual(buffer.findAllInRangeSync(/április/i, Range(Point(0, 0), Point(Infinity, Infinity))), [
+      assert.deepEqual(buffer.findAllInRangeSync(/április/iu, Range(Point(0, 0), Point(Infinity, Infinity))), [
         Range(Point(0, 4), Point(0, 11))
       ])
     })

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1192,6 +1192,13 @@ describe('TextBuffer', () => {
       const buffer = new TextBuffer('\r')
       assert.lengthOf(buffer.findAllInRangeSync(/./, Range(Point(0, 0), Point(Infinity, Infinity))), 0)
     })
+
+    it('uses unicode properties for case equivalence', () => {
+      const buffer = new TextBuffer('--- Április ---')
+      assert.deepEqual(buffer.findAllInRangeSync(/április/i, Range(Point(0, 0), Point(Infinity, Infinity))), [
+        Range(Point(0, 4), Point(0, 11))
+      ])
+    })
   })
 
   describe('.findAndMarkAllSync', () => {

--- a/vendor/pcre/include/config.h
+++ b/vendor/pcre/include/config.h
@@ -199,7 +199,7 @@ sure both macros are undefined; an emulation function will then be used. */
    at run time. The valid values are 1 (CR), 2 (LF), 3 (CRLF), 4 (ANY), and 5
    (ANYCRLF). */
 #ifndef NEWLINE_DEFAULT
-#define NEWLINE_DEFAULT 2
+#define NEWLINE_DEFAULT 4
 #endif
 
 /* Name of package */

--- a/vendor/pcre/include/config.h
+++ b/vendor/pcre/include/config.h
@@ -309,7 +309,9 @@ sure both macros are undefined; an emulation function will then be used. */
    will work even in an EBCDIC environment, but it is incompatible with the
    EBCDIC macro. That is, PCRE2 can support *either* EBCDIC code *or*
    ASCII/Unicode, but not both at once. */
-/* #undef SUPPORT_UNICODE */
+#ifndef SUPPORT_UNICODE
+# define SUPPORT_UNICODE 1
+#endif
 
 /* Define to any value for valgrind support to find invalid memory reads. */
 /* #undef SUPPORT_VALGRIND */


### PR DESCRIPTION
Enable Unicode support in pcre and compile regular expressions with `PCRE2_UTF`.

Fixes #56.
