### PR TITLE
Detect astral-plane characters

### DIFF
--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -87,6 +87,7 @@ EMSCRIPTEN_BINDINGS(TextBuffer) {
     .function("getLength", &TextBuffer::size)
     .function("getExtent", &TextBuffer::extent)
     .function("getLineCount", get_line_count)
+    .function("hasAstral", &TextBuffer::has_astral)
     .function("reset", WRAP(&TextBuffer::reset))
     .function("lineLengthForRow", WRAP(&TextBuffer::line_length_for_row))
     .function("lineEndingForRow", line_ending_for_row)

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -196,6 +196,7 @@ void TextBufferWrapper::init(Local<Object> exports) {
   prototype_template->Set(Nan::New("getLength").ToLocalChecked(), Nan::New<FunctionTemplate>(get_length));
   prototype_template->Set(Nan::New("getExtent").ToLocalChecked(), Nan::New<FunctionTemplate>(get_extent));
   prototype_template->Set(Nan::New("getLineCount").ToLocalChecked(), Nan::New<FunctionTemplate>(get_line_count));
+  prototype_template->Set(Nan::New("hasAstral").ToLocalChecked(), Nan::New<FunctionTemplate>(has_astral));
   prototype_template->Set(Nan::New("getTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text_in_range));
   prototype_template->Set(Nan::New("setTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(set_text_in_range));
   prototype_template->Set(Nan::New("getText").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text));
@@ -251,6 +252,11 @@ void TextBufferWrapper::get_extent(const Nan::FunctionCallbackInfo<Value> &info)
 void TextBufferWrapper::get_line_count(const Nan::FunctionCallbackInfo<Value> &info) {
   auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
   info.GetReturnValue().Set(Nan::New(text_buffer.extent().row + 1));
+}
+
+void TextBufferWrapper::has_astral(const Nan::FunctionCallbackInfo<Value> &info) {
+  auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
+  info.GetReturnValue().Set(Nan::New(text_buffer.has_astral()));
 }
 
 void TextBufferWrapper::get_text_in_range(const Nan::FunctionCallbackInfo<Value> &info) {

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -21,6 +21,7 @@ private:
   static void get_length(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_extent(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_line_count(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void has_astral(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_text(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_text_in_range(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void set_text(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -643,6 +643,20 @@ struct TextBuffer::Layer {
 
     return result;
   }
+
+  bool has_astral() {
+    bool result = false;
+    for_each_chunk_in_range(Point(), extent(), [&](TextSlice chunk) {
+      for (auto ch : chunk) {
+        if ((ch & 0xf800) == 0xd800) {
+          result = true;
+          return true;
+        }
+      }
+      return false;
+    });
+    return result;
+  }
 };
 
 TextBuffer::TextBuffer(u16string &&text) :
@@ -933,6 +947,10 @@ vector<SubsequenceMatch> TextBuffer::find_words_with_subsequence_in_range(const 
 
 bool TextBuffer::is_modified() const {
   return top_layer->is_modified(base_layer);
+}
+
+bool TextBuffer::has_astral() {
+  return top_layer->has_astral();
 }
 
 bool TextBuffer::is_modified(const Snapshot *snapshot) const {

--- a/src/core/text-buffer.h
+++ b/src/core/text-buffer.h
@@ -41,6 +41,7 @@ public:
   void set_text_in_range(Range old_range, std::u16string &&);
   void set_text_in_range(Range old_range, const std::u16string &);
   bool is_modified() const;
+  bool has_astral();
   std::vector<TextSlice> chunks() const;
 
   void reset(Text &&);

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -1392,6 +1392,18 @@ describe('TextBuffer', () => {
     })
   })
 
+  describe('.hasAstral', () => {
+    it('returns true on buffers that contain surrogate pairs', () => {
+      const buffer = new TextBuffer('coffee 😄')
+      assert.isTrue(buffer.hasAstral())
+    })
+
+    it('returns false on buffers that do not contain surrogate pairs', () => {
+      const buffer = new TextBuffer('no coffee')
+      assert.isFalse(buffer.hasAstral())
+    })
+  })
+
   describe('concurrent IO', function () {
     if (!TextBuffer.prototype.load) return;
 

--- a/test/native/text-buffer-test.cc
+++ b/test/native/text-buffer-test.cc
@@ -465,6 +465,11 @@ TEST_CASE("TextBuffer::find_words_with_subsequence_in_range") {
   }
 }
 
+TEST_CASE("TextBuffer::has_astral") {
+  REQUIRE(TextBuffer{u"ab" "\xd83d" "\xde01" "cd"}.has_astral());
+  REQUIRE(!TextBuffer{u"abcd"}.has_astral());
+}
+
 struct SnapshotData {
   Text base_text;
   u16string text;


### PR DESCRIPTION
Use `TextBuffer.has_astral()` to detect the presence of astral-plane unicode characters encoded as surrogate pairs. This will be useful to determine when a `/u` regex flag is required for searching, although it does incur an O(n) scan of the buffer contents.

The next part of #56.