### PR TITLE
Fix async_resource issues when loading files in Node 10 / Electron 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       XCODE_SCHEME: test
       XCODE_WORKSPACE: test
       XCODE_PROJECT: test
-      NODE_VERSION: '8.4'
+      NODE_VERSION: '10.2.1'
     macos:
       xcode: 8.3.3
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ notifications:
     on_failure: change
 
 node_js:
-  - node
+  - "8"
+  - "10"
 
 before_install:
   - export CXX="g++-4.9" CC="gcc-4.9"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 image: Visual Studio 2015
 
 environment:
-  nodejs_version: "8"
+  matrix:
+  - nodejs_version: "8"
+  - nodejs_version: "10"
 
 platform:
   - x86


### PR DESCRIPTION
In Node 10, using the original `async_resource` set on the Loader class causes an `EXC_BAD_ACCESS` segmentation fault when trying to create the asynchronous callback.  Passing along the caller's `async_resource` seems to provide the correct context for creating the callback.

I also added a code path that avoids a crash for the `loadSync` code path, using `Nan::Call` instead of invoking the callback with a null `async_resource`.