### PR TITLE
Add TextBuffer.prototype.characterAtPosition

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
   binding = require('./browser');
 
   const {TextBuffer, Patch} = binding
-  const {findSync, findAllSync, findAndMarkAllSync, findWordsWithSubsequenceInRange} = TextBuffer.prototype
+  const {findSync, findAllSync, findAndMarkAllSync, findWordsWithSubsequenceInRange, getCharacterAtPosition} = TextBuffer.prototype
   const DEFAULT_RANGE = Object.freeze({start: {row: 0, column: 0}, end: {row: Infinity, column: Infinity}})
 
   TextBuffer.prototype.findInRangeSync = function (pattern, range) {
@@ -93,6 +93,10 @@ if (process.env.SUPERSTRING_USE_BROWSER_VERSION) {
     return Promise.resolve(
       findWordsWithSubsequenceInRange.call(this, query, extraWordCharacters, range).slice(0, maxCount)
     )
+  }
+
+  TextBuffer.prototype.getCharacterAtPosition = function (position) {
+    return String.fromCharCode(getCharacterAtPosition.call(this, position))
   }
 
   const {compose} = Patch

--- a/src/bindings/em/text-buffer.cc
+++ b/src/bindings/em/text-buffer.cc
@@ -82,6 +82,7 @@ EMSCRIPTEN_BINDINGS(TextBuffer) {
     .constructor(construct, emscripten::allow_raw_pointers())
     .function("getText", WRAP(&TextBuffer::text))
     .function("setText", WRAP_OVERLOAD(&TextBuffer::set_text, void (TextBuffer::*)(u16string &&)))
+    .function("getCharacterAtPosition", WRAP(&TextBuffer::character_at))
     .function("getTextInRange", WRAP(&TextBuffer::text_in_range))
     .function("setTextInRange", WRAP_OVERLOAD(&TextBuffer::set_text_in_range, void (TextBuffer::*)(Range, u16string &&)))
     .function("getLength", &TextBuffer::size)

--- a/src/bindings/string-conversion.cc
+++ b/src/bindings/string-conversion.cc
@@ -35,3 +35,14 @@ Local<String> string_conversion::string_to_js(const u16string &text, const char 
     return Nan::New<String>("").ToLocalChecked();
   }
 }
+
+Local<String> string_conversion::char_to_js(const uint16_t c, const char *failure_message) {
+  Local<String> result;
+  if (Nan::New<String>(&c, 1).ToLocal(&result)) {
+    return result;
+  } else {
+    if (!failure_message) failure_message = "Couldn't convert character to a String";
+    Nan::ThrowError(failure_message);
+    return Nan::New<String>("").ToLocalChecked();
+  }
+}

--- a/src/bindings/string-conversion.h
+++ b/src/bindings/string-conversion.h
@@ -11,6 +11,10 @@ namespace string_conversion {
     const std::u16string &,
     const char *failure_message = nullptr
   );
+  v8::Local<v8::String> char_to_js(
+    const std::uint16_t,
+    const char *failure_message = nullptr
+  );
   optional<std::u16string> string_from_js(v8::Local<v8::Value>);
 };
 

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -198,6 +198,7 @@ void TextBufferWrapper::init(Local<Object> exports) {
   prototype_template->Set(Nan::New("getExtent").ToLocalChecked(), Nan::New<FunctionTemplate>(get_extent));
   prototype_template->Set(Nan::New("getLineCount").ToLocalChecked(), Nan::New<FunctionTemplate>(get_line_count));
   prototype_template->Set(Nan::New("hasAstral").ToLocalChecked(), Nan::New<FunctionTemplate>(has_astral));
+  prototype_template->Set(Nan::New("getCharacterAtPosition").ToLocalChecked(), Nan::New<FunctionTemplate>(get_character_at_position));
   prototype_template->Set(Nan::New("getTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text_in_range));
   prototype_template->Set(Nan::New("setTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(set_text_in_range));
   prototype_template->Set(Nan::New("getText").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text));
@@ -261,11 +262,18 @@ void TextBufferWrapper::has_astral(const Nan::FunctionCallbackInfo<Value> &info)
   info.GetReturnValue().Set(Nan::New(text_buffer.has_astral()));
 }
 
+void TextBufferWrapper::get_character_at_position(const Nan::FunctionCallbackInfo<Value> &info) {
+  auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
+  auto point = PointWrapper::point_from_js(info[0]);
+  if (point) {
+    info.GetReturnValue().Set(string_conversion::char_to_js(text_buffer.character_at(*point)));
+  }
+}
+
 void TextBufferWrapper::get_text_in_range(const Nan::FunctionCallbackInfo<Value> &info) {
   auto &text_buffer = Nan::ObjectWrap::Unwrap<TextBufferWrapper>(info.This())->text_buffer;
   auto range = RangeWrapper::range_from_js(info[0]);
   if (range) {
-    Local<String> result;
     info.GetReturnValue().Set(string_conversion::string_to_js(text_buffer.text_in_range(*range)));
   }
 }

--- a/src/bindings/text-buffer-wrapper.h
+++ b/src/bindings/text-buffer-wrapper.h
@@ -23,6 +23,7 @@ private:
   static void get_line_count(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void has_astral(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_text(const Nan::FunctionCallbackInfo<v8::Value> &info);
+  static void get_character_at_position(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void get_text_in_range(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void set_text(const Nan::FunctionCallbackInfo<v8::Value> &info);
   static void set_text_in_range(const Nan::FunctionCallbackInfo<v8::Value> &info);

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -869,6 +869,10 @@ u16string TextBuffer::text() {
   return top_layer->text_in_range(Range{Point(), extent()});
 }
 
+uint16_t TextBuffer::character_at(Point position) const {
+  return top_layer->character_at(position);
+}
+
 u16string TextBuffer::text_in_range(Range range) {
   return top_layer->text_in_range(range, true);
 }

--- a/src/core/text-buffer.h
+++ b/src/core/text-buffer.h
@@ -35,6 +35,7 @@ public:
   ClipResult clip_position(Point);
   Point position_for_offset(uint32_t offset);
   std::u16string text();
+  uint16_t character_at(Point position) const;
   std::u16string text_in_range(Range range);
   void set_text(std::u16string &&);
   void set_text(const std::u16string &);

--- a/test/js/text-buffer.test.js
+++ b/test/js/text-buffer.test.js
@@ -776,6 +776,19 @@ describe('TextBuffer', () => {
     })
   })
 
+  describe('.getCharacterAtPosition', () => {
+    it('return a character at the given position', () => {
+      const buffer = new TextBuffer()
+      buffer.setText('abc\ndef\nghi')
+      assert.equal(buffer.getCharacterAtPosition(Point(0, 0)), 'a')
+      assert.equal(buffer.getCharacterAtPosition(Point(0, 1)), 'b')
+      assert.equal(buffer.getCharacterAtPosition(Point(0, 3)), '\n')
+      assert.equal(buffer.getCharacterAtPosition(Point(0, 100)), '\n')
+      assert.equal(buffer.getCharacterAtPosition(Point(2, 0)), 'g')
+      assert.equal(buffer.getCharacterAtPosition(Point(3, 0)), '\u0000')
+    })
+  })
+
   describe('.getTextInRange', () => {
     it('reads substrings from the buffer', () => {
       const buffer = new TextBuffer()
@@ -786,6 +799,8 @@ describe('TextBuffer', () => {
 
       assert.equal(buffer.getTextInRange(Range(Point(-Infinity, -Infinity), Point(0, Infinity))), 'abc')
       assert.equal(buffer.getTextInRange(Range(Point(1, -Infinity), Point(1, Infinity))), 'def')
+
+      assert.equal(buffer.getTextInRange(Range(Point(3, 0), Point(5, 5))), '')
     })
   })
 


### PR DESCRIPTION
🍐'd with @rafeca

We're adding this so we can avoid calling `lineForRow` in certain performance-sensitive code paths, since this can be quite slow for files with extremely long lines.
