### PR TITLE
Replace deprecated V8 API usages with Nan

### DIFF
--- a/src/bindings/marker-index-wrapper.cc
+++ b/src/bindings/marker-index-wrapper.cc
@@ -30,32 +30,32 @@ void MarkerIndexWrapper::init(Local<Object> exports) {
 
   const auto &prototype_template = constructor_template->PrototypeTemplate();
 
-  prototype_template->Set(Nan::New<String>("delete").ToLocalChecked(), Nan::New<FunctionTemplate>(noop));
-  prototype_template->Set(Nan::New<String>("generateRandomNumber").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(generate_random_number));
-  prototype_template->Set(Nan::New<String>("insert").ToLocalChecked(), Nan::New<FunctionTemplate>(insert));
-  prototype_template->Set(Nan::New<String>("setExclusive").ToLocalChecked(), Nan::New<FunctionTemplate>(set_exclusive));
-  prototype_template->Set(Nan::New<String>("remove").ToLocalChecked(), Nan::New<FunctionTemplate>(remove));
-  prototype_template->Set(Nan::New<String>("has").ToLocalChecked(), Nan::New<FunctionTemplate>(has));
-  prototype_template->Set(Nan::New<String>("splice").ToLocalChecked(), Nan::New<FunctionTemplate>(splice));
-  prototype_template->Set(Nan::New<String>("getStart").ToLocalChecked(), Nan::New<FunctionTemplate>(get_start));
-  prototype_template->Set(Nan::New<String>("getEnd").ToLocalChecked(), Nan::New<FunctionTemplate>(get_end));
-  prototype_template->Set(Nan::New<String>("getRange").ToLocalChecked(), Nan::New<FunctionTemplate>(get_range));
-  prototype_template->Set(Nan::New<String>("compare").ToLocalChecked(), Nan::New<FunctionTemplate>(compare));
-  prototype_template->Set(Nan::New<String>("findIntersecting").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(find_intersecting));
-  prototype_template->Set(Nan::New<String>("findContaining").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(find_containing));
-  prototype_template->Set(Nan::New<String>("findContainedIn").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(find_contained_in));
-  prototype_template->Set(Nan::New<String>("findStartingIn").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(find_starting_in));
-  prototype_template->Set(Nan::New<String>("findStartingAt").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(find_starting_at));
-  prototype_template->Set(Nan::New<String>("findEndingIn").ToLocalChecked(), Nan::New<FunctionTemplate>(find_ending_in));
-  prototype_template->Set(Nan::New<String>("findEndingAt").ToLocalChecked(), Nan::New<FunctionTemplate>(find_ending_at));
-  prototype_template->Set(Nan::New<String>("findBoundariesAfter").ToLocalChecked(), Nan::New<FunctionTemplate>(find_boundaries_after));
-  prototype_template->Set(Nan::New<String>("dump").ToLocalChecked(), Nan::New<FunctionTemplate>(dump));
+  Nan::SetTemplate(prototype_template, Nan::New<String>("delete").ToLocalChecked(), Nan::New<FunctionTemplate>(noop), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("generateRandomNumber").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(generate_random_number), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("insert").ToLocalChecked(), Nan::New<FunctionTemplate>(insert), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("setExclusive").ToLocalChecked(), Nan::New<FunctionTemplate>(set_exclusive), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("remove").ToLocalChecked(), Nan::New<FunctionTemplate>(remove), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("has").ToLocalChecked(), Nan::New<FunctionTemplate>(has), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("splice").ToLocalChecked(), Nan::New<FunctionTemplate>(splice), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("getStart").ToLocalChecked(), Nan::New<FunctionTemplate>(get_start), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("getEnd").ToLocalChecked(), Nan::New<FunctionTemplate>(get_end), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("getRange").ToLocalChecked(), Nan::New<FunctionTemplate>(get_range), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("compare").ToLocalChecked(), Nan::New<FunctionTemplate>(compare), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findIntersecting").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(find_intersecting), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findContaining").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(find_containing), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findContainedIn").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(find_contained_in), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findStartingIn").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(find_starting_in), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findStartingAt").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(find_starting_at), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findEndingIn").ToLocalChecked(), Nan::New<FunctionTemplate>(find_ending_in), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findEndingAt").ToLocalChecked(), Nan::New<FunctionTemplate>(find_ending_at), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("findBoundariesAfter").ToLocalChecked(), Nan::New<FunctionTemplate>(find_boundaries_after), None);
+  Nan::SetTemplate(prototype_template, Nan::New<String>("dump").ToLocalChecked(), Nan::New<FunctionTemplate>(dump), None);
 
   start_string.Reset(Nan::Persistent<String>(Nan::New("start").ToLocalChecked()));
   end_string.Reset(Nan::Persistent<String>(Nan::New("end").ToLocalChecked()));
@@ -110,7 +110,7 @@ Local<Set> MarkerIndexWrapper::marker_ids_set_to_js(const MarkerIndex::MarkerIdS
 Local<Array> MarkerIndexWrapper::marker_ids_vector_to_js(const std::vector<MarkerIndex::MarkerId> &marker_ids) {
   Local<Array> js_array = Nan::New<Array>(marker_ids.size());
   for (size_t i = 0; i < marker_ids.size(); i++) {
-    js_array->Set(i, Nan::New<Integer>(marker_ids[i]));
+    Nan::Set(js_array, i, Nan::New<Integer>(marker_ids[i]));
   }
   return js_array;
 }
@@ -119,9 +119,9 @@ Local<Object> MarkerIndexWrapper::snapshot_to_js(const unordered_map<MarkerIndex
   Local<Object> result_object = Nan::New<Object>();
   for (auto &pair : snapshot) {
     Local<Object> range = Nan::New<Object>();
-    range->Set(Nan::New(start_string), PointWrapper::from_point(pair.second.start));
-    range->Set(Nan::New(end_string), PointWrapper::from_point(pair.second.end));
-    result_object->Set(Nan::New<Integer>(pair.first), range);
+    Nan::Set(range, Nan::New(start_string), PointWrapper::from_point(pair.second.start));
+    Nan::Set(range, Nan::New(end_string), PointWrapper::from_point(pair.second.end));
+    Nan::Set(result_object, Nan::New<Integer>(pair.first), range);
   }
   return result_object;
 }
@@ -207,11 +207,11 @@ void MarkerIndexWrapper::splice(const Nan::FunctionCallbackInfo<Value> &info) {
     MarkerIndex::SpliceResult result = wrapper->marker_index.splice(*start, *old_extent, *new_extent);
 
     Local<Object> invalidated = Nan::New<Object>();
-    invalidated->Set(Nan::New(touch_string), marker_ids_set_to_js(result.touch));
-    invalidated->Set(Nan::New(inside_string), marker_ids_set_to_js(result.inside));
-    invalidated->Set(Nan::New(inside_string), marker_ids_set_to_js(result.inside));
-    invalidated->Set(Nan::New(overlap_string), marker_ids_set_to_js(result.overlap));
-    invalidated->Set(Nan::New(surround_string), marker_ids_set_to_js(result.surround));
+    Nan::Set(invalidated, Nan::New(touch_string), marker_ids_set_to_js(result.touch));
+    Nan::Set(invalidated, Nan::New(inside_string), marker_ids_set_to_js(result.inside));
+    Nan::Set(invalidated, Nan::New(inside_string), marker_ids_set_to_js(result.inside));
+    Nan::Set(invalidated, Nan::New(overlap_string), marker_ids_set_to_js(result.overlap));
+    Nan::Set(invalidated, Nan::New(surround_string), marker_ids_set_to_js(result.surround));
     info.GetReturnValue().Set(invalidated);
   }
 }
@@ -243,8 +243,8 @@ void MarkerIndexWrapper::get_range(const Nan::FunctionCallbackInfo<Value> &info)
   if (id) {
     Range range = wrapper->marker_index.get_range(*id);
     auto result = Nan::New<Object>();
-    result->Set(Nan::New(start_string), PointWrapper::from_point(range.start));
-    result->Set(Nan::New(end_string), PointWrapper::from_point(range.end));
+    Nan::Set(result, Nan::New(start_string), PointWrapper::from_point(range.start));
+    Nan::Set(result, Nan::New(end_string), PointWrapper::from_point(range.end));
     info.GetReturnValue().Set(result);
   }
 }
@@ -353,18 +353,18 @@ void MarkerIndexWrapper::find_boundaries_after(const Nan::FunctionCallbackInfo<V
   if (start && max_count) {
     MarkerIndex::BoundaryQueryResult result = wrapper->marker_index.find_boundaries_after(*start, *max_count);
     Local<Object> js_result = Nan::New<Object>();
-    js_result->Set(Nan::New(containing_start_string), marker_ids_vector_to_js(result.containing_start));
+    Nan::Set(js_result, Nan::New(containing_start_string), marker_ids_vector_to_js(result.containing_start));
 
     Local<Array> js_boundaries = Nan::New<Array>(result.boundaries.size());
     for (size_t i = 0; i < result.boundaries.size(); i++) {
       MarkerIndex::Boundary boundary = result.boundaries[i];
       Local<Object> js_boundary = Nan::New<Object>();
-      js_boundary->Set(Nan::New(position_string), PointWrapper::from_point(boundary.position));
-      js_boundary->Set(Nan::New(starting_string), marker_ids_set_to_js(boundary.starting));
-      js_boundary->Set(Nan::New(ending_string), marker_ids_set_to_js(boundary.ending));
-      js_boundaries->Set(i, js_boundary);
+      Nan::Set(js_boundary, Nan::New(position_string), PointWrapper::from_point(boundary.position));
+      Nan::Set(js_boundary, Nan::New(starting_string), marker_ids_set_to_js(boundary.starting));
+      Nan::Set(js_boundary, Nan::New(ending_string), marker_ids_set_to_js(boundary.ending));
+      Nan::Set(js_boundaries, i, js_boundary);
     }
-    js_result->Set(Nan::New(boundaries_string), js_boundaries);
+    Nan::Set(js_result, Nan::New(boundaries_string), js_boundaries);
 
     info.GetReturnValue().Set(js_result);
   }

--- a/src/bindings/patch-wrapper.cc
+++ b/src/bindings/patch-wrapper.cc
@@ -36,7 +36,7 @@ class ChangeWrapper : public Nan::ObjectWrap {
     Nan::SetAccessor(instance_template, Nan::New("newEnd").ToLocalChecked(), get_new_end);
 
     const auto &prototype_template = constructor_template->PrototypeTemplate();
-    prototype_template->Set(Nan::New<String>("toString").ToLocalChecked(), Nan::New<FunctionTemplate>(to_string));
+    Nan::SetTemplate(prototype_template, Nan::New<String>("toString").ToLocalChecked(), Nan::New<FunctionTemplate>(to_string), None);
     change_wrapper_constructor.Reset(Nan::GetFunction(constructor_template).ToLocalChecked());
   }
 
@@ -45,13 +45,15 @@ class ChangeWrapper : public Nan::ObjectWrap {
     if (Nan::NewInstance(Nan::New(change_wrapper_constructor)).ToLocal(&result)) {
       (new ChangeWrapper(change))->Wrap(result);
       if (change.new_text) {
-        result->Set(
+        Nan::Set(
+          result,
           Nan::New(new_text_string),
           string_conversion::string_to_js(change.new_text->content)
         );
       }
       if (change.old_text) {
-        result->Set(
+        Nan::Set(
+          result,
           Nan::New(old_text_string),
           string_conversion::string_to_js(change.old_text->content)
         );
@@ -112,33 +114,33 @@ void PatchWrapper::init(Local<Object> exports) {
 
   Local<FunctionTemplate> constructor_template_local = Nan::New<FunctionTemplate>(construct);
   constructor_template_local->SetClassName(Nan::New<String>("Patch").ToLocalChecked());
-  constructor_template_local->Set(Nan::New("deserialize").ToLocalChecked(), Nan::New<FunctionTemplate>(deserialize));
-  constructor_template_local->Set(Nan::New("compose").ToLocalChecked(), Nan::New<FunctionTemplate>(compose));
+  Nan::SetTemplate(constructor_template_local, Nan::New("deserialize").ToLocalChecked(), Nan::New<FunctionTemplate>(deserialize), None);
+  Nan::SetTemplate(constructor_template_local, Nan::New("compose").ToLocalChecked(), Nan::New<FunctionTemplate>(compose), None);
   constructor_template_local->InstanceTemplate()->SetInternalFieldCount(1);
   const auto &prototype_template = constructor_template_local->PrototypeTemplate();
-  prototype_template->Set(Nan::New("delete").ToLocalChecked(), Nan::New<FunctionTemplate>(noop));
-  prototype_template->Set(Nan::New("splice").ToLocalChecked(), Nan::New<FunctionTemplate>(splice));
-  prototype_template->Set(Nan::New("spliceOld").ToLocalChecked(), Nan::New<FunctionTemplate>(splice_old));
-  prototype_template->Set(Nan::New("copy").ToLocalChecked(), Nan::New<FunctionTemplate>(copy));
-  prototype_template->Set(Nan::New("invert").ToLocalChecked(), Nan::New<FunctionTemplate>(invert));
-  prototype_template->Set(Nan::New("getChanges").ToLocalChecked(), Nan::New<FunctionTemplate>(get_changes));
-  prototype_template->Set(Nan::New("getChangesInOldRange").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(get_changes_in_old_range));
-  prototype_template->Set(Nan::New("getChangesInNewRange").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(get_changes_in_new_range));
-  prototype_template->Set(Nan::New("changeForOldPosition").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(change_for_old_position));
-  prototype_template->Set(Nan::New("changeForNewPosition").ToLocalChecked(),
-                          Nan::New<FunctionTemplate>(change_for_new_position));
-  prototype_template->Set(Nan::New("serialize").ToLocalChecked(), Nan::New<FunctionTemplate>(serialize));
-  prototype_template->Set(Nan::New("getDotGraph").ToLocalChecked(), Nan::New<FunctionTemplate>(get_dot_graph));
-  prototype_template->Set(Nan::New("getJSON").ToLocalChecked(), Nan::New<FunctionTemplate>(get_json));
-  prototype_template->Set(Nan::New("rebalance").ToLocalChecked(), Nan::New<FunctionTemplate>(rebalance));
-  prototype_template->Set(Nan::New("getChangeCount").ToLocalChecked(), Nan::New<FunctionTemplate>(get_change_count));
-  prototype_template->Set(Nan::New("getBounds").ToLocalChecked(), Nan::New<FunctionTemplate>(get_bounds));
+  Nan::SetTemplate(prototype_template, Nan::New("delete").ToLocalChecked(), Nan::New<FunctionTemplate>(noop), None);
+  Nan::SetTemplate(prototype_template, Nan::New("splice").ToLocalChecked(), Nan::New<FunctionTemplate>(splice), None);
+  Nan::SetTemplate(prototype_template, Nan::New("spliceOld").ToLocalChecked(), Nan::New<FunctionTemplate>(splice_old), None);
+  Nan::SetTemplate(prototype_template, Nan::New("copy").ToLocalChecked(), Nan::New<FunctionTemplate>(copy), None);
+  Nan::SetTemplate(prototype_template, Nan::New("invert").ToLocalChecked(), Nan::New<FunctionTemplate>(invert), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getChanges").ToLocalChecked(), Nan::New<FunctionTemplate>(get_changes), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getChangesInOldRange").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(get_changes_in_old_range), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getChangesInNewRange").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(get_changes_in_new_range), None);
+  Nan::SetTemplate(prototype_template, Nan::New("changeForOldPosition").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(change_for_old_position), None);
+  Nan::SetTemplate(prototype_template, Nan::New("changeForNewPosition").ToLocalChecked(),
+                          Nan::New<FunctionTemplate>(change_for_new_position), None);
+  Nan::SetTemplate(prototype_template, Nan::New("serialize").ToLocalChecked(), Nan::New<FunctionTemplate>(serialize), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getDotGraph").ToLocalChecked(), Nan::New<FunctionTemplate>(get_dot_graph), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getJSON").ToLocalChecked(), Nan::New<FunctionTemplate>(get_json), None);
+  Nan::SetTemplate(prototype_template, Nan::New("rebalance").ToLocalChecked(), Nan::New<FunctionTemplate>(rebalance), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getChangeCount").ToLocalChecked(), Nan::New<FunctionTemplate>(get_change_count), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getBounds").ToLocalChecked(), Nan::New<FunctionTemplate>(get_bounds), None);
   patch_wrapper_constructor_template.Reset(constructor_template_local);
   patch_wrapper_constructor.Reset(Nan::GetFunction(constructor_template_local).ToLocalChecked());
-  exports->Set(Nan::New("Patch").ToLocalChecked(), Nan::New(patch_wrapper_constructor));
+  Nan::Set(exports, Nan::New("Patch").ToLocalChecked(), Nan::New(patch_wrapper_constructor));
 }
 
 PatchWrapper::PatchWrapper(Patch &&patch) : patch{std::move(patch)} {}
@@ -241,7 +243,7 @@ void PatchWrapper::get_changes(const Nan::FunctionCallbackInfo<Value> &info) {
 
   size_t i = 0;
   for (auto change : patch.get_changes()) {
-    js_result->Set(i++, ChangeWrapper::FromChange(change));
+    Nan::Set(js_result, i++, ChangeWrapper::FromChange(change));
   }
 
   info.GetReturnValue().Set(js_result);
@@ -258,7 +260,7 @@ void PatchWrapper::get_changes_in_old_range(const Nan::FunctionCallbackInfo<Valu
 
     size_t i = 0;
     for (auto change : patch.grab_changes_in_old_range(*start, *end)) {
-      js_result->Set(i++, ChangeWrapper::FromChange(change));
+      Nan::Set(js_result, i++, ChangeWrapper::FromChange(change));
     }
 
     info.GetReturnValue().Set(js_result);
@@ -276,7 +278,7 @@ void PatchWrapper::get_changes_in_new_range(const Nan::FunctionCallbackInfo<Valu
 
     size_t i = 0;
     for (auto change : patch.grab_changes_in_new_range(*start, *end)) {
-      js_result->Set(i++, ChangeWrapper::FromChange(change));
+      Nan::Set(js_result, i++, ChangeWrapper::FromChange(change));
     }
 
     info.GetReturnValue().Set(js_result);
@@ -352,12 +354,12 @@ void PatchWrapper::compose(const Nan::FunctionCallbackInfo<Value> &info) {
     Patch combination;
     bool left_to_right = true;
     for (uint32_t i = 0, n = js_patches->Length(); i < n; i++) {
-      if (!js_patches->Get(i)->IsObject()) {
+      if (!Nan::Get(js_patches, i).ToLocalChecked()->IsObject()) {
         Nan::ThrowTypeError("Patch.compose must be called with an array of patches");
         return;
       }
 
-      Local<Object> js_patch = Local<Object>::Cast(js_patches->Get(i));
+      Local<Object> js_patch = Local<Object>::Cast(Nan::Get(js_patches, i).ToLocalChecked());
       if (!Nan::New(patch_wrapper_constructor_template)->HasInstance(js_patch)) {
         Nan::ThrowTypeError("Patch.compose must be called with an array of patches");
         return;

--- a/src/bindings/point-wrapper.cc
+++ b/src/bindings/point-wrapper.cc
@@ -25,14 +25,14 @@ optional<Point> PointWrapper::point_from_js(Local<Value> value) {
     return optional<Point>{};
   }
 
-  Nan::MaybeLocal<Integer> maybe_row = Nan::To<Integer>(object->Get(Nan::New(row_string)));
+  Nan::MaybeLocal<Integer> maybe_row = Nan::To<Integer>(Nan::Get(object, Nan::New(row_string)).ToLocalChecked());
   Local<Integer> js_row;
   if (!maybe_row.ToLocal(&js_row)) {
     Nan::ThrowTypeError("Expected an object with 'row' and 'column' properties.");
     return optional<Point>{};
   }
 
-  Nan::MaybeLocal<Integer> maybe_column = Nan::To<Integer>(object->Get(Nan::New(column_string)));
+  Nan::MaybeLocal<Integer> maybe_column = Nan::To<Integer>(Nan::Get(object, Nan::New(column_string)).ToLocalChecked());
   Local<Integer> js_column;
   if (!maybe_column.ToLocal(&js_column)) {
     Nan::ThrowTypeError("Expected an object with 'row' and 'column' properties.");

--- a/src/bindings/range-wrapper.cc
+++ b/src/bindings/range-wrapper.cc
@@ -15,8 +15,8 @@ optional<Range> RangeWrapper::range_from_js(Local<Value> value) {
     return optional<Range>{};
   }
 
-  auto start = PointWrapper::point_from_js(object->Get(Nan::New(start_string)));
-  auto end = PointWrapper::point_from_js(object->Get(Nan::New(end_string)));
+  auto start = PointWrapper::point_from_js(Nan::Get(object, Nan::New(start_string)).ToLocalChecked());
+  auto end = PointWrapper::point_from_js(Nan::Get(object, Nan::New(end_string)).ToLocalChecked());
   if (start && end) {
     return Range{*start, *end};
   } else {

--- a/src/bindings/text-buffer-snapshot-wrapper.cc
+++ b/src/bindings/text-buffer-snapshot-wrapper.cc
@@ -14,7 +14,7 @@ void TextBufferSnapshotWrapper::init() {
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
 
   const auto &prototype_template = constructor_template->PrototypeTemplate();
-  prototype_template->Set(Nan::New("destroy").ToLocalChecked(), Nan::New<FunctionTemplate>(destroy));
+  Nan::SetTemplate(prototype_template, Nan::New("destroy").ToLocalChecked(), Nan::New<FunctionTemplate>(destroy), None);
 
   snapshot_wrapper_constructor.Reset(Nan::GetFunction(constructor_template).ToLocalChecked());
 }

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -91,7 +91,7 @@ class RegexWrapper : public Nan::ObjectWrap {
       js_pattern = Local<String>::Cast(value);
     } else if (value->IsRegExp()) {
       js_regex = Local<RegExp>::Cast(value);
-      Local<Value> stored_regex = js_regex->Get(cache_key);
+      Local<Value> stored_regex = Nan::Get(js_regex, cache_key).ToLocalChecked();
       if (!stored_regex->IsUndefined()) {
         return &Nan::ObjectWrap::Unwrap<RegexWrapper>(Nan::To<Object>(stored_regex).ToLocalChecked())->regex;
       }
@@ -119,7 +119,7 @@ class RegexWrapper : public Nan::ObjectWrap {
 
     auto regex_wrapper = new RegexWrapper(move(regex));
     regex_wrapper->Wrap(result);
-    if (!js_regex.IsEmpty()) js_regex->Set(cache_key, result);
+    if (!js_regex.IsEmpty()) Nan::Set(js_regex, cache_key, result);
     return &regex_wrapper->regex;
   }
 
@@ -173,7 +173,7 @@ public:
     SubsequenceMatch &match = Nan::ObjectWrap::Unwrap<SubsequenceMatchWrapper>(info.This())->match;
     Local<Array> js_result = Nan::New<Array>();
     for (size_t i = 0; i < match.match_indices.size(); i++) {
-      js_result->Set(i, Nan::New<Integer>(match.match_indices[i]));
+      Nan::Set(js_result, i, Nan::New<Integer>(match.match_indices[i]));
     }
     info.GetReturnValue().Set(js_result);
   }
@@ -193,42 +193,42 @@ void TextBufferWrapper::init(Local<Object> exports) {
   constructor_template->SetClassName(Nan::New<String>("TextBuffer").ToLocalChecked());
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   const auto &prototype_template = constructor_template->PrototypeTemplate();
-  prototype_template->Set(Nan::New("delete").ToLocalChecked(), Nan::New<FunctionTemplate>(noop));
-  prototype_template->Set(Nan::New("getLength").ToLocalChecked(), Nan::New<FunctionTemplate>(get_length));
-  prototype_template->Set(Nan::New("getExtent").ToLocalChecked(), Nan::New<FunctionTemplate>(get_extent));
-  prototype_template->Set(Nan::New("getLineCount").ToLocalChecked(), Nan::New<FunctionTemplate>(get_line_count));
-  prototype_template->Set(Nan::New("hasAstral").ToLocalChecked(), Nan::New<FunctionTemplate>(has_astral));
-  prototype_template->Set(Nan::New("getCharacterAtPosition").ToLocalChecked(), Nan::New<FunctionTemplate>(get_character_at_position));
-  prototype_template->Set(Nan::New("getTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text_in_range));
-  prototype_template->Set(Nan::New("setTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(set_text_in_range));
-  prototype_template->Set(Nan::New("getText").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text));
-  prototype_template->Set(Nan::New("setText").ToLocalChecked(), Nan::New<FunctionTemplate>(set_text));
-  prototype_template->Set(Nan::New("lineForRow").ToLocalChecked(), Nan::New<FunctionTemplate>(line_for_row));
-  prototype_template->Set(Nan::New("lineLengthForRow").ToLocalChecked(), Nan::New<FunctionTemplate>(line_length_for_row));
-  prototype_template->Set(Nan::New("lineEndingForRow").ToLocalChecked(), Nan::New<FunctionTemplate>(line_ending_for_row));
-  prototype_template->Set(Nan::New("getLines").ToLocalChecked(), Nan::New<FunctionTemplate>(get_lines));
-  prototype_template->Set(Nan::New("characterIndexForPosition").ToLocalChecked(), Nan::New<FunctionTemplate>(character_index_for_position));
-  prototype_template->Set(Nan::New("positionForCharacterIndex").ToLocalChecked(), Nan::New<FunctionTemplate>(position_for_character_index));
-  prototype_template->Set(Nan::New("isModified").ToLocalChecked(), Nan::New<FunctionTemplate>(is_modified));
-  prototype_template->Set(Nan::New("load").ToLocalChecked(), Nan::New<FunctionTemplate>(load));
-  prototype_template->Set(Nan::New("baseTextMatchesFile").ToLocalChecked(), Nan::New<FunctionTemplate>(base_text_matches_file));
-  prototype_template->Set(Nan::New("save").ToLocalChecked(), Nan::New<FunctionTemplate>(save));
-  prototype_template->Set(Nan::New("loadSync").ToLocalChecked(), Nan::New<FunctionTemplate>(load_sync));
-  prototype_template->Set(Nan::New("serializeChanges").ToLocalChecked(), Nan::New<FunctionTemplate>(serialize_changes));
-  prototype_template->Set(Nan::New("deserializeChanges").ToLocalChecked(), Nan::New<FunctionTemplate>(deserialize_changes));
-  prototype_template->Set(Nan::New("reset").ToLocalChecked(), Nan::New<FunctionTemplate>(reset));
-  prototype_template->Set(Nan::New("baseTextDigest").ToLocalChecked(), Nan::New<FunctionTemplate>(base_text_digest));
-  prototype_template->Set(Nan::New("find").ToLocalChecked(), Nan::New<FunctionTemplate>(find));
-  prototype_template->Set(Nan::New("findSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_sync));
-  prototype_template->Set(Nan::New("findAll").ToLocalChecked(), Nan::New<FunctionTemplate>(find_all));
-  prototype_template->Set(Nan::New("findAllSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_all_sync));
-  prototype_template->Set(Nan::New("findAndMarkAllSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_and_mark_all_sync));
-  prototype_template->Set(Nan::New("findWordsWithSubsequenceInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(find_words_with_subsequence_in_range));
-  prototype_template->Set(Nan::New("getDotGraph").ToLocalChecked(), Nan::New<FunctionTemplate>(dot_graph));
-  prototype_template->Set(Nan::New("getSnapshot").ToLocalChecked(), Nan::New<FunctionTemplate>(get_snapshot));
+  Nan::SetTemplate(prototype_template, Nan::New("delete").ToLocalChecked(), Nan::New<FunctionTemplate>(noop), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getLength").ToLocalChecked(), Nan::New<FunctionTemplate>(get_length), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getExtent").ToLocalChecked(), Nan::New<FunctionTemplate>(get_extent), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getLineCount").ToLocalChecked(), Nan::New<FunctionTemplate>(get_line_count), None);
+  Nan::SetTemplate(prototype_template, Nan::New("hasAstral").ToLocalChecked(), Nan::New<FunctionTemplate>(has_astral), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getCharacterAtPosition").ToLocalChecked(), Nan::New<FunctionTemplate>(get_character_at_position), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text_in_range), None);
+  Nan::SetTemplate(prototype_template, Nan::New("setTextInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(set_text_in_range), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getText").ToLocalChecked(), Nan::New<FunctionTemplate>(get_text), None);
+  Nan::SetTemplate(prototype_template, Nan::New("setText").ToLocalChecked(), Nan::New<FunctionTemplate>(set_text), None);
+  Nan::SetTemplate(prototype_template, Nan::New("lineForRow").ToLocalChecked(), Nan::New<FunctionTemplate>(line_for_row), None);
+  Nan::SetTemplate(prototype_template, Nan::New("lineLengthForRow").ToLocalChecked(), Nan::New<FunctionTemplate>(line_length_for_row), None);
+  Nan::SetTemplate(prototype_template, Nan::New("lineEndingForRow").ToLocalChecked(), Nan::New<FunctionTemplate>(line_ending_for_row), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getLines").ToLocalChecked(), Nan::New<FunctionTemplate>(get_lines), None);
+  Nan::SetTemplate(prototype_template, Nan::New("characterIndexForPosition").ToLocalChecked(), Nan::New<FunctionTemplate>(character_index_for_position), None);
+  Nan::SetTemplate(prototype_template, Nan::New("positionForCharacterIndex").ToLocalChecked(), Nan::New<FunctionTemplate>(position_for_character_index), None);
+  Nan::SetTemplate(prototype_template, Nan::New("isModified").ToLocalChecked(), Nan::New<FunctionTemplate>(is_modified), None);
+  Nan::SetTemplate(prototype_template, Nan::New("load").ToLocalChecked(), Nan::New<FunctionTemplate>(load), None);
+  Nan::SetTemplate(prototype_template, Nan::New("baseTextMatchesFile").ToLocalChecked(), Nan::New<FunctionTemplate>(base_text_matches_file), None);
+  Nan::SetTemplate(prototype_template, Nan::New("save").ToLocalChecked(), Nan::New<FunctionTemplate>(save), None);
+  Nan::SetTemplate(prototype_template, Nan::New("loadSync").ToLocalChecked(), Nan::New<FunctionTemplate>(load_sync), None);
+  Nan::SetTemplate(prototype_template, Nan::New("serializeChanges").ToLocalChecked(), Nan::New<FunctionTemplate>(serialize_changes), None);
+  Nan::SetTemplate(prototype_template, Nan::New("deserializeChanges").ToLocalChecked(), Nan::New<FunctionTemplate>(deserialize_changes), None);
+  Nan::SetTemplate(prototype_template, Nan::New("reset").ToLocalChecked(), Nan::New<FunctionTemplate>(reset), None);
+  Nan::SetTemplate(prototype_template, Nan::New("baseTextDigest").ToLocalChecked(), Nan::New<FunctionTemplate>(base_text_digest), None);
+  Nan::SetTemplate(prototype_template, Nan::New("find").ToLocalChecked(), Nan::New<FunctionTemplate>(find), None);
+  Nan::SetTemplate(prototype_template, Nan::New("findSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_sync), None);
+  Nan::SetTemplate(prototype_template, Nan::New("findAll").ToLocalChecked(), Nan::New<FunctionTemplate>(find_all), None);
+  Nan::SetTemplate(prototype_template, Nan::New("findAllSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_all_sync), None);
+  Nan::SetTemplate(prototype_template, Nan::New("findAndMarkAllSync").ToLocalChecked(), Nan::New<FunctionTemplate>(find_and_mark_all_sync), None);
+  Nan::SetTemplate(prototype_template, Nan::New("findWordsWithSubsequenceInRange").ToLocalChecked(), Nan::New<FunctionTemplate>(find_words_with_subsequence_in_range), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getDotGraph").ToLocalChecked(), Nan::New<FunctionTemplate>(dot_graph), None);
+  Nan::SetTemplate(prototype_template, Nan::New("getSnapshot").ToLocalChecked(), Nan::New<FunctionTemplate>(get_snapshot), None);
   RegexWrapper::init();
   SubsequenceMatchWrapper::init();
-  exports->Set(Nan::New("TextBuffer").ToLocalChecked(), Nan::GetFunction(constructor_template).ToLocalChecked());
+  Nan::Set(exports, Nan::New("TextBuffer").ToLocalChecked(), Nan::GetFunction(constructor_template).ToLocalChecked());
 }
 
 void TextBufferWrapper::construct(const Nan::FunctionCallbackInfo<Value> &info) {
@@ -354,7 +354,7 @@ void TextBufferWrapper::get_lines(const Nan::FunctionCallbackInfo<Value> &info) 
 
   for (uint32_t row = 0, row_count = text_buffer.extent().row + 1; row < row_count; row++) {
     auto text = text_buffer.text_in_range({{row, 0}, {row, UINT32_MAX}});
-    result->Set(row, string_conversion::string_to_js(text));
+    Nan::Set(result, row, string_conversion::string_to_js(text));
   }
 
   info.GetReturnValue().Set(result);
@@ -624,7 +624,7 @@ void TextBufferWrapper::find_words_with_subsequence_in_range(const Nan::Function
           bytes_to_copy
         );
         positions_array_index += bytes_to_copy / sizeof(uint32_t);
-        js_matches_array->Set(i, SubsequenceMatchWrapper::from_subsequence_match(match));
+        Nan::Set(js_matches_array, i, SubsequenceMatchWrapper::from_subsequence_match(match));
       }
 
       auto positions_array = v8::Uint32Array::New(positions_buffer, 0, positions_buffer_size / sizeof(uint32_t));

--- a/src/bindings/text-reader.cc
+++ b/src/bindings/text-reader.cc
@@ -12,10 +12,10 @@ void TextReader::init(Local<Object> exports) {
   constructor_template->SetClassName(Nan::New<String>("TextReader").ToLocalChecked());
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   const auto &prototype_template = constructor_template->PrototypeTemplate();
-  prototype_template->Set(Nan::New("read").ToLocalChecked(), Nan::New<FunctionTemplate>(read));
-  prototype_template->Set(Nan::New("end").ToLocalChecked(), Nan::New<FunctionTemplate>(end));
-  prototype_template->Set(Nan::New("destroy").ToLocalChecked(), Nan::New<FunctionTemplate>(destroy));
-  exports->Set(Nan::New("TextReader").ToLocalChecked(), Nan::GetFunction(constructor_template).ToLocalChecked());
+  Nan::SetTemplate(prototype_template, Nan::New("read").ToLocalChecked(), Nan::New<FunctionTemplate>(read), None);
+  Nan::SetTemplate(prototype_template, Nan::New("end").ToLocalChecked(), Nan::New<FunctionTemplate>(end), None);
+  Nan::SetTemplate(prototype_template, Nan::New("destroy").ToLocalChecked(), Nan::New<FunctionTemplate>(destroy), None);
+  Nan::Set(exports, Nan::New("TextReader").ToLocalChecked(), Nan::GetFunction(constructor_template).ToLocalChecked());
 }
 
 TextReader::TextReader(Local<Object> js_buffer,

--- a/src/bindings/text-writer.cc
+++ b/src/bindings/text-writer.cc
@@ -10,9 +10,9 @@ void TextWriter::init(Local<Object> exports) {
   constructor_template->SetClassName(Nan::New<String>("TextWriter").ToLocalChecked());
   constructor_template->InstanceTemplate()->SetInternalFieldCount(1);
   const auto &prototype_template = constructor_template->PrototypeTemplate();
-  prototype_template->Set(Nan::New("write").ToLocalChecked(), Nan::New<FunctionTemplate>(write));
-  prototype_template->Set(Nan::New("end").ToLocalChecked(), Nan::New<FunctionTemplate>(end));
-  exports->Set(Nan::New("TextWriter").ToLocalChecked(), Nan::GetFunction(constructor_template).ToLocalChecked());
+  Nan::SetTemplate(prototype_template, Nan::New("write").ToLocalChecked(), Nan::New<FunctionTemplate>(write), None);
+  Nan::SetTemplate(prototype_template, Nan::New("end").ToLocalChecked(), Nan::New<FunctionTemplate>(end), None);
+  Nan::Set(exports, Nan::New("TextWriter").ToLocalChecked(), Nan::GetFunction(constructor_template).ToLocalChecked());
 }
 
 TextWriter::TextWriter(EncodingConversion &&conversion) : conversion{move(conversion)} {}


### PR DESCRIPTION
Replaces deprecated Object::Set, Object::Get and Template::Set calls
with corresponding Nan calls for better Node version compatibility.

Fixes #76.