### PR TITLE
Add clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: "*, -clang-diagnostic-*-compat, -cppcoreguidelines-init-variables, -modernize-return-braced-init-list, -misc-unused-parameters, -misc-non-private-member-variables-in-classes, -llvmlibc-*, -llvm-header-guard, -llvm-include-order, -modernize-use-trailing-return-type, -readability-avoid-const-params-in-decls, -readability-convert-member-functions-to-static, -fuchsia-default-arguments-declarations, -fuchsia-default-arguments-calls, -*-uppercase-literal-suffix, -fuchsia-overloaded-operator, -google-build-using-namespace, -google-global-names-in-headers, -google-readability-todo, -*-else-after-return, -*-braces-around-statements"
+HeaderFilterRegex: ".*"
+FormatStyle: none

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "benchmark": "node benchmark/marker-index.benchmark.js",
     "prepublishOnly": "npm run build:browser",
     "standard": "standard --recursive src test",
+    "format": "clang-format -i src/core/*.cc src/core/*.h src/bindings/*.cc src/bindings/*.h src/bindings/em/*.cc src/bindings/em/*.h",
     "tidy": "clang-tidy src/core/*.cc src/core/*.h src/bindings/*.cc src/bindings/*.h src/bindings/em/*.cc src/bindings/em/*.h",
     "tidy:fix": "npm run tidy -- --fix --fix-errors"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "test": "npm run test:node && npm run test:browser",
     "benchmark": "node benchmark/marker-index.benchmark.js",
     "prepublishOnly": "npm run build:browser",
-    "standard": "standard --recursive src test"
+    "standard": "standard --recursive src test",
+    "tidy": "clang-tidy src/core/*.cc src/core/*.h src/bindings/*.cc src/bindings/*.h src/bindings/em/*.cc src/bindings/em/*.h",
+    "tidy:fix": "npm run tidy -- --fix --fix-errors"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description of the change

This adds clang-tidy configuration and scripts. 

### Benefits 
Clang-tidy allows us to find the bugs and improve performance

### Verification
I have not still run the tidy on the codebase. This PR just adds the facilities for it.

Running clang-tidy is possible using the following commands (running takes some time).
```
npm run tidy
```
or
```
npm run tidy:fix
```


### Release Notes
N/A