### PR TITLE
use constexpr instead of static const

### DIFF
--- a/src/bindings/patch-wrapper.cc
+++ b/src/bindings/patch-wrapper.cc
@@ -17,7 +17,7 @@ static Nan::Persistent<v8::Function> change_wrapper_constructor;
 static Nan::Persistent<v8::FunctionTemplate> patch_wrapper_constructor_template;
 static Nan::Persistent<v8::Function> patch_wrapper_constructor;
 
-static const char *InvalidSpliceMessage = "Patch does not apply";
+constexpr char *InvalidSpliceMessage = "Patch does not apply";
 
 class ChangeWrapper : public Nan::ObjectWrap {
  public:

--- a/src/bindings/text-buffer-wrapper.cc
+++ b/src/bindings/text-buffer-wrapper.cc
@@ -665,7 +665,7 @@ void TextBufferWrapper::is_modified(const Nan::FunctionCallbackInfo<Value> &info
   info.GetReturnValue().Set(Nan::New<Boolean>(text_buffer.is_modified()));
 }
 
-static const int INVALID_ENCODING = -1;
+constexpr int INVALID_ENCODING = -1;
 
 struct Error {
   int number;

--- a/src/core/encoding-conversion.cc
+++ b/src/core/encoding-conversion.cc
@@ -7,10 +7,10 @@ using std::function;
 using std::u16string;
 using std::vector;
 
-static const uint32_t bytes_per_character = (sizeof(uint16_t) / sizeof(char));
-static const uint16_t replacement_character = 0xFFFD;
-static const size_t conversion_failure = static_cast<size_t>(-1);
-static const float buffer_growth_factor = 2;
+constexpr uint32_t bytes_per_character = (sizeof(uint16_t) / sizeof(char));
+constexpr uint16_t replacement_character = 0xFFFD;
+constexpr size_t conversion_failure = static_cast<size_t>(-1);
+constexpr float buffer_growth_factor = 2;
 
 enum Mode {
   GENERAL,

--- a/src/core/patch.cc
+++ b/src/core/patch.cc
@@ -17,7 +17,7 @@ using std::ostream;
 using std::endl;
 using Change = Patch::Change;
 
-static const uint32_t SERIALIZATION_VERSION = 1;
+constexpr uint32_t SERIALIZATION_VERSION = 1;
 
 struct Patch::Node {
   Node *left;

--- a/src/core/text-buffer.cc
+++ b/src/core/text-buffer.cc
@@ -523,11 +523,11 @@ struct TextBuffer::Layer {
     // Next, calculate a score for each word indicating the quality of the
     // match against the query.
 
-    static const unsigned consecutive_bonus = 5;
-    static const unsigned subword_start_with_case_match_bonus = 10;
-    static const unsigned subword_start_with_case_mismatch_bonus = 9;
-    static const unsigned mismatch_penalty = 1;
-    static const unsigned leading_mismatch_penalty = 3;
+    constexpr unsigned consecutive_bonus = 5;
+    constexpr unsigned subword_start_with_case_match_bonus = 10;
+    constexpr unsigned subword_start_with_case_mismatch_bonus = 9;
+    constexpr unsigned mismatch_penalty = 1;
+    constexpr unsigned leading_mismatch_penalty = 3;
 
     vector<SubsequenceMatch> matches;
 


### PR DESCRIPTION
### Description of the change

This uses constexpr instead of static const for compile-time variables

constexpr variable is guaranteed to have a value available at compile-time. whereas static const members or const variables could either mean a 
compile-time value or a runtime value.

### Verifications 
Tests pass

### Release Notes
N/A