### PR TITLE
Download submodules before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:browser": "SUPERSTRING_USE_BROWSER_VERSION=1 mocha test/js/*.js",
     "test": "npm run test:node && npm run test:browser",
     "benchmark": "node benchmark/marker-index.benchmark.js",
-    "prepublishOnly": "npm run build:browser",
+    "prepublishOnly": "git submodule update --init --recursive && npm run build:browser",
     "standard": "standard --recursive src test"
   },
   "repository": {


### PR DESCRIPTION
### Description of the change

This adds a script to download the submodules before publishing it to npm.


### Verification
Running the following downloads win-iconv
```
git submodule update --init --recursive 
```

Fixes https://github.com/atom/atom/pull/21782