### PR TITLE
Fix large-text-buffer benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 /browser.js
 emsdk-portable
 package-lock.json
+
+benchmark/*.csv

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -23,11 +23,10 @@ async function getText() {
 getText().then(txt => {
   const buffer = new TextBuffer()
 
-  console.log('running findWordsWithSubsequence tests...')
+  console.log('\n running findWordsWithSubsequence tests... \n')
 
   const sizes = [ ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
-  const word = "Morocco"
   const test = (word, size) => {
     buffer.setText(txt.slice(0, size[1]))
     const ti = performance.now()
@@ -37,9 +36,11 @@ getText().then(txt => {
     })
   }
 
-  return sizes.reduce((promise, size) => {
-    return promise.then(() => test(word, size))
-  }, Promise.resolve())
+  for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {
+    sizes.reduce((promise, size) => {
+      return promise.then(() => test(word, size))
+    }, Promise.resolve())
+  }
 }).then(() => {
-  console.log('finished')
+  console.log('findWordsWithSubsequence tests finished \n')
 })

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -27,13 +27,12 @@ getText().then(async (txt) => {
 
   const sizes = [ ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
-  const test = (word, size) => {
+  const test = async (word, size) => {
     buffer.setText(txt.slice(0, size[1]))
     const ti = performance.now()
-    return buffer.findWordsWithSubsequence(word, '', 100).then(sugs => {
-      const tf = performance.now()
-      console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
-    })
+    await buffer.findWordsWithSubsequence(word, '', 100)
+    const tf = performance.now()
+    console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
   }
   for (const size of sizes) {
     for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -5,6 +5,7 @@ const {promisify} = require('util')
 const readFile = promisify(fs.readFile)
 const path = require('path')
 const download = require('download')
+const {performance} = require("perf_hooks")
 
 async function getText() {
   const filePath = path.join(__dirname, '1000000 Sales Records.csv')
@@ -19,8 +20,6 @@ async function getText() {
   return await readFile(filePath)
 }
 
-const timer = size => `Time to find "cat" in ${size} file`
-
 getText().then(txt => {
   const buffer = new TextBuffer()
 
@@ -28,17 +27,18 @@ getText().then(txt => {
 
   const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
-  const test = size => {
-    const _timer = timer(size[0])
+  const word = "Morocco"
+  const test = (word, size) => {
     buffer.setText(txt.slice(0, size[1]))
-    console.time(_timer)
-    return buffer.findWordsWithSubsequence('cat', '', 100).then(sugs => {
-      console.timeEnd(_timer)
+    const ti = performance.now()
+    return buffer.findWordsWithSubsequence(word, '', 100).then(sugs => {
+      const tf = performance.now()
+      console.log(`Time to find "${word}" in ${size[0]} file: ${(tf-ti).toFixed(5)} ms`)
     })
   }
 
   return sizes.reduce((promise, size) => {
-    return promise.then(() => test(size))
+    return promise.then(() => test(word, size))
   }, Promise.resolve())
 }).then(() => {
   console.log('finished')

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -25,7 +25,7 @@ getText().then(txt => {
 
   console.log('running findWordsWithSubsequence tests...')
 
-  const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
+  const sizes = [ ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
   const word = "Morocco"
   const test = (word, size) => {

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -20,7 +20,7 @@ async function getText() {
   return await readFile(filePath)
 }
 
-getText().then(txt => {
+getText().then(async (txt) => {
   const buffer = new TextBuffer()
 
   console.log('\n running findWordsWithSubsequence tests... \n')
@@ -35,11 +35,11 @@ getText().then(txt => {
       console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
     })
   }
-
-  for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {
-    sizes.reduce((promise, size) => {
-      return promise.then(() => test(word, size))
-    }, Promise.resolve())
+  for (const size of sizes) {
+    for (const word of ["Morocco", "Austria", "France", "Liechtenstein", "Republic of the Congo", "Antigua and Barbuda", "Japan"]) {
+      await test(word, size)
+    }
+    console.log('\n')
   }
 }).then(() => {
   console.log('findWordsWithSubsequence tests finished \n')

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -1,33 +1,22 @@
-const http = require('http')
-const fs = require('fs')
-const unzip = require('unzip')
 const { TextBuffer } = require('..')
 
-const unzipper = unzip.Parse()
+const fs = require('fs')
+const {promisify} = require('util')
+const readFile = promisify(fs.readFile)
+const path = require('path')
+const download = require('download')
 
-const getText = () => {
-  return new Promise(resolve => {
-    console.log('fetching text file...')
-    const req = http.get({
-      hostname: 'www.acleddata.com',
-      port: 80,
-      // 51 MB text file
-      path: '/wp-content/uploads/2017/01/ACLED-Version-7-All-Africa-1997-2016_csv_dyadic-file.zip',
-      agent: false
-    }, res => {
-      res
-        .pipe(unzipper)
-        .on('entry', entry => {
-          let data = '';
-          entry.on('data', chunk => data += chunk);
-          entry.on('end', () => {
-            resolve(data)
-          });
-        })
-    })
-
-    req.end()
-  })
+async function getText() {
+  const filePath = path.join(__dirname, '1000000 Sales Records.csv')
+  if (!fs.existsSync(filePath)) {
+    // 122MB file
+    await download(
+      'http://eforexcel.com/wp/wp-content/uploads/2017/07/1000000%20Sales%20Records.zip',
+      __dirname,
+      {extract: true}
+    )
+  }
+  return await readFile(filePath)
 }
 
 const timer = size => `Time to find "cat" in ${size} file`

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -32,7 +32,7 @@ getText().then(txt => {
     const ti = performance.now()
     return buffer.findWordsWithSubsequence(word, '', 100).then(sugs => {
       const tf = performance.now()
-      console.log(`Time to find "${word}" in ${size[0]} file: ${(tf-ti).toFixed(5)} ms`)
+      console.log(`In ${size[0]} file, time to find "${word}" was: ${' '.repeat(50-word.length-size[0].length)} ${(tf-ti).toFixed(5)} ms`)
     })
   }
 

--- a/benchmark/large-text-buffer.benchmark.js
+++ b/benchmark/large-text-buffer.benchmark.js
@@ -26,7 +26,7 @@ getText().then(txt => {
 
   console.log('running findWordsWithSubsequence tests...')
 
-  const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000]]
+  const sizes = [['10b', 10], ['100b', 100], ['1kb', 1000], ['1MB', 1000000], ['51MB', 100000000], ['119MB', txt.length]]
 
   const test = size => {
     const _timer = timer(size[0])

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:node": "mocha test/js/*.js",
     "test:browser": "SUPERSTRING_USE_BROWSER_VERSION=1 mocha test/js/*.js",
     "test": "npm run test:node && npm run test:browser",
-    "benchmark": "node benchmark/marker-index.benchmark.js",
+    "benchmark": "node benchmark/marker-index.benchmark.js && node benchmark/large-text-buffer.benchmark.js",
     "prepublishOnly": "git submodule update --init --recursive && npm run build:browser",
     "standard": "standard --recursive src test"
   },

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "devDependencies": {
     "chai": "^2.0.0",
+    "download": "^8.0.0",
     "mocha": "^2.3.4",
     "random-seed": "^0.2.0",
     "standard": "^4.5.4",
-    "temp": "^0.8.3",
-    "unzip": "^0.1.11"
+    "temp": "^0.8.3"
   },
   "standard": {
     "global": [


### PR DESCRIPTION
### Description of the change

This fixes large-text-buffer benchmarks that were broken before this. 
- Now, a new csv large file is downloaded from a new link (the old file is not available anymore).
- uses download package instead of non-working unzip package
- makes the test runners async
- runs the tests for different words

### Verifications
```
npm install
npm run benchmark
```


### Release Notes
N/A


